### PR TITLE
[codex] bump mcp-ts-core to ^0.3.5 and release 0.3.8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 **Version:** 0.3.7
 **Framework:** [@cyanheads/mcp-ts-core](https://www.npmjs.com/package/@cyanheads/mcp-ts-core)
 
-> **Read the framework docs first:** `node_modules/@cyanheads/mcp-ts-core/CLAUDE.md` contains the full API reference — builders, Context, error codes, exports, patterns. This file covers server-specific conventions only.
+> **Read the framework docs first:** `node_modules/@cyanheads/mcp-ts-core/AGENTS.md` contains the full API reference — builders, Context, error codes, exports, patterns. This file covers server-specific conventions only.
 
 ---
 
@@ -18,7 +18,7 @@ MCP server wrapping the [Congress.gov API v3](https://api.congress.gov/) — the
 
 When the user asks what to do next, what's left, or needs direction, suggest relevant options based on the current project state:
 
-1. **Re-run the `setup` skill** — ensures CLAUDE.md, skills, structure, and metadata are populated and up to date with the current codebase
+1. **Re-run the `setup` skill** — ensures AGENTS.md, skills, structure, and metadata are populated and up to date with the current codebase
 2. **Run the `design-mcp-server` skill** — if the tool/resource surface hasn't been mapped yet, work through domain design
 3. **Add tools/resources/prompts** — scaffold new definitions using the `add-tool`, `add-resource`, `add-prompt` skills
 4. **Add services** — scaffold domain service integrations using the `add-service` skill
@@ -193,7 +193,7 @@ import { getServerConfig } from '@/config/server-config.js';
 
 Skills are modular instructions in `skills/` at the project root. Read them directly when a task matches — e.g., `skills/add-tool/SKILL.md` when adding a tool.
 
-**Agent skill directory:** Copy skills into the directory your agent discovers (Claude Code: `.claude/skills/`, others: equivalent). This makes skills available as context without needing to reference `skills/` paths manually. After framework updates, re-copy to pick up changes.
+**Agent skill directory:** Copy skills into the directory your agent discovers (Codex: `.Codex/skills/`, others: equivalent). This makes skills available as context without needing to reference `skills/` paths manually. After framework updates, re-copy to pick up changes.
 
 Available skills:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Protocol
 
 **Server:** congressgov-mcp-server
-**Version:** 0.3.7
+**Version:** 0.3.8
 **Framework:** [@cyanheads/mcp-ts-core](https://www.npmjs.com/package/@cyanheads/mcp-ts-core)
 
 > **Read the framework docs first:** `node_modules/@cyanheads/mcp-ts-core/AGENTS.md` contains the full API reference — builders, Context, error codes, exports, patterns. This file covers server-specific conventions only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.3.8] - 2026-04-18
+## [0.3.8] - 2026-04-19
 
 ### Added
 
@@ -12,13 +12,15 @@
 
 - Bumped `@cyanheads/mcp-ts-core` from `^0.2.10` to `^0.3.5`
 - Bumped `@biomejs/biome` from `^2.4.10` to `^2.4.12`, `@types/node` from `^25.5.0` to `^25.6.0`, `typescript` from `^6.0.2` to `^6.0.3`, and `vitest` from `^4.1.2` to `^4.1.4`
-- Updated Congress.gov tool and resource outputs to use stricter schemas, preserve pagination and `rawResponse` metadata, and pass request context through service calls
-- Updated markdown formatters to surface upstream URLs, improve empty-field handling, and note when `rawResponse` includes fuller upstream data
-- Updated `CongressApiService` to use framework retry and timeout utilities, preserve upstream envelopes, and carry request context and abort signals through HTTP calls
+- Updated Congress.gov tool and resource outputs to use stricter schemas, preserve pagination metadata, and pass request context through service calls. Tools return only normalized fields (`data`/`pagination` for lists, `bill`/`member`/`committee`/etc. for details) — upstream envelopes are no longer duplicated in structured output
+- Updated markdown formatters to surface upstream URLs and improve empty-field handling
+- Updated `CongressApiService` to use framework retry and timeout utilities, and carry request context and abort signals through HTTP calls
 - Updated project skills for direct `createApp()` registration guidance, external-service resilience, testing layout, field-test coverage, and devcheck expectations
+- Dropped the `overrides` block for `brace-expansion` and `path-to-regexp` — upstream chains now resolve to patched versions and `bun audit` is clean without them
 
 ### Fixed
 
+- Fixed `getLaw` returning an empty `law` field — Congress.gov returns the law endpoint payload under `bill`, not `law`, so the normalized field was always undefined. Added a service-level test asserting `result.law` is populated
 - Fixed CRS report error handling to distinguish structured upstream "not found" responses from real service outages
 - Fixed member lookup validation to reject ambiguous `congress` and location filters instead of silently dropping one
 - Fixed the `CLAUDE.md` commands table to use `bun run test`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.3.8] - 2026-04-18
+
+### Added
+
+- Added `AGENTS.md` for non-Claude agents
+- Added the `add-app-tool` skill for MCP Apps tool and UI resource scaffolding
+- Added shared tool schema helpers in `src/mcp-server/tools/tool-helpers.ts`
+
+### Changed
+
+- Bumped `@cyanheads/mcp-ts-core` from `^0.2.10` to `^0.3.5`
+- Bumped `@biomejs/biome` from `^2.4.10` to `^2.4.12`, `@types/node` from `^25.5.0` to `^25.6.0`, `typescript` from `^6.0.2` to `^6.0.3`, and `vitest` from `^4.1.2` to `^4.1.4`
+- Updated Congress.gov tool and resource outputs to use stricter schemas, preserve pagination and `rawResponse` metadata, and pass request context through service calls
+- Updated markdown formatters to surface upstream URLs, improve empty-field handling, and note when `rawResponse` includes fuller upstream data
+- Updated `CongressApiService` to use framework retry and timeout utilities, preserve upstream envelopes, and carry request context and abort signals through HTTP calls
+- Updated project skills for direct `createApp()` registration guidance, external-service resilience, testing layout, field-test coverage, and devcheck expectations
+
+### Fixed
+
+- Fixed CRS report error handling to distinguish structured upstream "not found" responses from real service outages
+- Fixed member lookup validation to reject ambiguous `congress` and location filters instead of silently dropping one
+- Fixed the `CLAUDE.md` commands table to use `bun run test`
+
 ## [0.3.7] - 2026-03-30
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Agent Protocol
 
 **Server:** congressgov-mcp-server
-**Version:** 0.3.7
+**Version:** 0.3.8
 **Framework:** [@cyanheads/mcp-ts-core](https://www.npmjs.com/package/@cyanheads/mcp-ts-core)
 
 > **Read the framework docs first:** `node_modules/@cyanheads/mcp-ts-core/CLAUDE.md` contains the full API reference — builders, Context, error codes, exports, patterns. This file covers server-specific conventions only.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <div align="center">
 
-[![npm](https://img.shields.io/npm/v/@cyanheads/congressgov-mcp-server?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/@cyanheads/congressgov-mcp-server) [![Version](https://img.shields.io/badge/Version-0.3.7-blue.svg?style=flat-square)](./CHANGELOG.md) [![Framework](https://img.shields.io/badge/Built%20on-@cyanheads/mcp--ts--core-259?style=flat-square)](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.27.1-green.svg?style=flat-square)](https://modelcontextprotocol.io/)
+[![npm](https://img.shields.io/npm/v/@cyanheads/congressgov-mcp-server?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/@cyanheads/congressgov-mcp-server) [![Version](https://img.shields.io/badge/Version-0.3.8-blue.svg?style=flat-square)](./CHANGELOG.md) [![Framework](https://img.shields.io/badge/Built%20on-@cyanheads/mcp--ts--core-259?style=flat-square)](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.27.1-green.svg?style=flat-square)](https://modelcontextprotocol.io/)
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg?style=flat-square)](./LICENSE) [![TypeScript](https://img.shields.io/badge/TypeScript-^6.0.3-3178C6.svg?style=flat-square)](https://www.typescriptlang.org/) [![Bun](https://img.shields.io/badge/Bun-v1.3.2-blueviolet.svg?style=flat-square)](https://bun.sh/)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![npm](https://img.shields.io/npm/v/@cyanheads/congressgov-mcp-server?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/@cyanheads/congressgov-mcp-server) [![Version](https://img.shields.io/badge/Version-0.3.7-blue.svg?style=flat-square)](./CHANGELOG.md) [![Framework](https://img.shields.io/badge/Built%20on-@cyanheads/mcp--ts--core-259?style=flat-square)](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.27.1-green.svg?style=flat-square)](https://modelcontextprotocol.io/)
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg?style=flat-square)](./LICENSE) [![TypeScript](https://img.shields.io/badge/TypeScript-^6.0.2-3178C6.svg?style=flat-square)](https://www.typescriptlang.org/) [![Bun](https://img.shields.io/badge/Bun-v1.3.2-blueviolet.svg?style=flat-square)](https://bun.sh/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg?style=flat-square)](./LICENSE) [![TypeScript](https://img.shields.io/badge/TypeScript-^6.0.3-3178C6.svg?style=flat-square)](https://www.typescriptlang.org/) [![Bun](https://img.shields.io/badge/Bun-v1.3.2-blueviolet.svg?style=flat-square)](https://bun.sh/)
 
 </div>
 

--- a/bun.lock
+++ b/bun.lock
@@ -42,25 +42,25 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.12", "@biomejs/cli-darwin-x64": "2.4.12", "@biomejs/cli-linux-arm64": "2.4.12", "@biomejs/cli-linux-arm64-musl": "2.4.12", "@biomejs/cli-linux-x64": "2.4.12", "@biomejs/cli-linux-x64-musl": "2.4.12", "@biomejs/cli-win32-arm64": "2.4.12", "@biomejs/cli-win32-x64": "2.4.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.12", "", { "os": "win32", "cpu": "x64" }, "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA=="],
 
-    "@cyanheads/mcp-ts-core": ["@cyanheads/mcp-ts-core@0.2.10", "", { "dependencies": { "@hono/mcp": "^0.2.5", "@hono/node-server": "^1.19.12", "@modelcontextprotocol/ext-apps": "^1.3.2", "@modelcontextprotocol/sdk": "^1.28.0", "dotenv": "^17.3.1", "hono": "^4.12.9", "jose": "^6.2.2", "pino": "^10.3.1", "zod": "^4.3.6" }, "peerDependencies": { "@hono/otel": "^1.1.1", "@opentelemetry/api": "^1.9.1", "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0", "@opentelemetry/exporter-trace-otlp-http": "^0.214.0", "@opentelemetry/instrumentation-http": "^0.214.0", "@opentelemetry/instrumentation-pino": "^0.60.0", "@opentelemetry/resources": "^2.6.0", "@opentelemetry/sdk-metrics": "^2.6.0", "@opentelemetry/sdk-node": "^0.214.0", "@opentelemetry/sdk-trace-node": "^2.6.0", "@opentelemetry/semantic-conventions": "^1.40.0", "@supabase/supabase-js": "^2.99.3", "chrono-node": "^2.9.0", "diff": "^8.0.4", "fast-xml-parser": "latest", "js-yaml": "^4.1.0", "node-cron": "^4.2.1", "openai": "^6.32.0", "papaparse": "^5.5.3", "partial-json": "^0.1.7", "pdf-lib": "^1.17.1", "sanitize-html": "^2.17.2", "unpdf": "^1.4.0", "validator": "^13.15.26" }, "optionalPeers": ["@hono/otel", "@opentelemetry/api", "@opentelemetry/exporter-metrics-otlp-http", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation-http", "@opentelemetry/instrumentation-pino", "@opentelemetry/resources", "@opentelemetry/sdk-metrics", "@opentelemetry/sdk-node", "@opentelemetry/sdk-trace-node", "@opentelemetry/semantic-conventions", "@supabase/supabase-js", "chrono-node", "diff", "fast-xml-parser", "js-yaml", "node-cron", "openai", "papaparse", "partial-json", "pdf-lib", "sanitize-html", "unpdf", "validator"], "bin": { "mcp-ts-core": "dist/cli/init.js" } }, "sha512-owz4g23eSg9pNiAnoMUopj7N7s55X0JOREC2j5KK7c06YERRDa7PVbUamGNd3244uSNpgiWdnFO8cKsy6Ea9xw=="],
+    "@cyanheads/mcp-ts-core": ["@cyanheads/mcp-ts-core@0.3.5", "", { "dependencies": { "@hono/mcp": "^0.2.5", "@hono/node-server": "^1.19.13", "@modelcontextprotocol/ext-apps": "^1.5.0", "@modelcontextprotocol/sdk": "^1.29.0", "@opentelemetry/api": "^1.9.1", "dotenv": "^17.4.1", "hono": "^4.12.12", "jose": "^6.2.2", "pino": "^10.3.1", "zod": "^4.3.6" }, "peerDependencies": { "@hono/otel": "^1.1.1", "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0", "@opentelemetry/exporter-trace-otlp-http": "^0.214.0", "@opentelemetry/instrumentation-http": "^0.214.0", "@opentelemetry/instrumentation-pino": "^0.60.0", "@opentelemetry/resources": "^2.6.0", "@opentelemetry/sdk-metrics": "^2.6.0", "@opentelemetry/sdk-node": "^0.214.0", "@opentelemetry/sdk-trace-node": "^2.6.0", "@opentelemetry/semantic-conventions": "^1.40.0", "@supabase/supabase-js": "^2.99.3", "chrono-node": "^2.9.0", "diff": "^8.0.4", "fast-xml-parser": "latest", "js-yaml": "^4.1.0", "node-cron": "^4.2.1", "openai": "^6.32.0", "papaparse": "^5.5.3", "partial-json": "^0.1.7", "pdf-lib": "^1.17.1", "sanitize-html": "^2.17.2", "unpdf": "^1.4.0", "validator": "^13.15.26" }, "optionalPeers": ["@hono/otel", "@opentelemetry/exporter-metrics-otlp-http", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation-http", "@opentelemetry/instrumentation-pino", "@opentelemetry/resources", "@opentelemetry/sdk-metrics", "@opentelemetry/sdk-node", "@opentelemetry/sdk-trace-node", "@opentelemetry/semantic-conventions", "@supabase/supabase-js", "chrono-node", "diff", "fast-xml-parser", "js-yaml", "node-cron", "openai", "papaparse", "partial-json", "pdf-lib", "sanitize-html", "unpdf", "validator"], "bin": { "mcp-ts-core": "dist/cli/init.js" } }, "sha512-jfiOtMV0vOv5DZfG6ASxQojIA0GryArgnSYYtS9A6j2KQzsAhhrsN00+dW7d1SNxKTvsbzkJxAveYsMPtJQ21w=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -122,7 +122,7 @@
 
     "@hono/mcp": ["@hono/mcp@0.2.5", "", { "dependencies": { "pkce-challenge": "^5.0.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.1", "hono": "*", "hono-rate-limiter": "^0.4.2", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-JsaJes7VlNvUrUQ9j2b9C13xjFLvyKQY515aWtsdJ9cwhBmWz5od2yUCbDu7cX38GeADmlLmpu4BKNNAV6G27w=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -132,9 +132,9 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@1.3.2", "", { "peerDependencies": { "@modelcontextprotocol/sdk": "^1.24.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-DGG1FxN3s8g4KV+BF64dxph8j2mtxgU56Lu/WgBjylomqRIPshW0ut47OtBN4+V8r+Qp8kKUvCOBBzPY9+GurA=="],
+    "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@1.6.0", "", { "peerDependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-j80Hv9kSALu7luR+DtoYERlRaehu6cY2wlHEjG3h36C98bbYzA/nxOEvtGhhKd2ssCwC0BG3+gdh7y3sE5m0tQ=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.28.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -144,7 +144,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
 
@@ -194,23 +194,23 @@
 
     "@types/minimatch": ["@types/minimatch@3.0.5", "", {}, "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="],
 
-    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.2", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ=="],
+    "@vitest/expect": ["@vitest/expect@4.1.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.2", "", { "dependencies": { "@vitest/spy": "4.1.2", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.4", "", { "dependencies": { "@vitest/spy": "4.1.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.2", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.2", "", { "dependencies": { "@vitest/utils": "4.1.2", "pathe": "^2.0.3" } }, "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ=="],
+    "@vitest/runner": ["@vitest/runner@4.1.4", "", { "dependencies": { "@vitest/utils": "4.1.4", "pathe": "^2.0.3" } }, "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "@vitest/utils": "4.1.2", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "@vitest/utils": "4.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.2", "", {}, "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA=="],
+    "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ=="],
+    "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.30", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/shared": "3.5.30", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw=="],
 
@@ -314,7 +314,7 @@
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
-    "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -416,7 +416,7 @@
 
     "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
 
-    "hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "hono-rate-limiter": ["hono-rate-limiter@0.4.2", "", { "peerDependencies": { "hono": "^4.1.1" } }, "sha512-AAtFqgADyrmbDijcRTT/HJfwqfvhalya2Zo+MgfdrMPas3zSMD8SU03cv+ZsYwRU1swv7zgVt0shwN059yzhjw=="],
 
@@ -704,9 +704,9 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -714,7 +714,7 @@
 
     "vite": ["vite@8.0.2", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.11", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA=="],
 
-    "vitest": ["vitest@4.1.2", "", { "dependencies": { "@vitest/expect": "4.1.2", "@vitest/mocker": "4.1.2", "@vitest/pretty-format": "4.1.2", "@vitest/runner": "4.1.2", "@vitest/snapshot": "4.1.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.2", "@vitest/browser-preview": "4.1.2", "@vitest/browser-webdriverio": "4.1.2", "@vitest/ui": "4.1.2", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg=="],
+    "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -735,8 +735,6 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
-
-    "@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "congressgov-mcp-server",
+      "name": "@cyanheads/congressgov-mcp-server",
       "dependencies": {
         "@cyanheads/mcp-ts-core": "latest",
         "pino-pretty": "latest",
@@ -18,10 +18,6 @@
         "vitest": "latest",
       },
     },
-  },
-  "overrides": {
-    "brace-expansion": ">=2.0.3",
-    "path-to-regexp": ">=8.4.0",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -62,63 +58,11 @@
 
     "@cyanheads/mcp-ts-core": ["@cyanheads/mcp-ts-core@0.3.5", "", { "dependencies": { "@hono/mcp": "^0.2.5", "@hono/node-server": "^1.19.13", "@modelcontextprotocol/ext-apps": "^1.5.0", "@modelcontextprotocol/sdk": "^1.29.0", "@opentelemetry/api": "^1.9.1", "dotenv": "^17.4.1", "hono": "^4.12.12", "jose": "^6.2.2", "pino": "^10.3.1", "zod": "^4.3.6" }, "peerDependencies": { "@hono/otel": "^1.1.1", "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0", "@opentelemetry/exporter-trace-otlp-http": "^0.214.0", "@opentelemetry/instrumentation-http": "^0.214.0", "@opentelemetry/instrumentation-pino": "^0.60.0", "@opentelemetry/resources": "^2.6.0", "@opentelemetry/sdk-metrics": "^2.6.0", "@opentelemetry/sdk-node": "^0.214.0", "@opentelemetry/sdk-trace-node": "^2.6.0", "@opentelemetry/semantic-conventions": "^1.40.0", "@supabase/supabase-js": "^2.99.3", "chrono-node": "^2.9.0", "diff": "^8.0.4", "fast-xml-parser": "latest", "js-yaml": "^4.1.0", "node-cron": "^4.2.1", "openai": "^6.32.0", "papaparse": "^5.5.3", "partial-json": "^0.1.7", "pdf-lib": "^1.17.1", "sanitize-html": "^2.17.2", "unpdf": "^1.4.0", "validator": "^13.15.26" }, "optionalPeers": ["@hono/otel", "@opentelemetry/exporter-metrics-otlp-http", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation-http", "@opentelemetry/instrumentation-pino", "@opentelemetry/resources", "@opentelemetry/sdk-metrics", "@opentelemetry/sdk-node", "@opentelemetry/sdk-trace-node", "@opentelemetry/semantic-conventions", "@supabase/supabase-js", "chrono-node", "diff", "fast-xml-parser", "js-yaml", "node-cron", "openai", "papaparse", "partial-json", "pdf-lib", "sanitize-html", "unpdf", "validator"], "bin": { "mcp-ts-core": "dist/cli/init.js" } }, "sha512-jfiOtMV0vOv5DZfG6ASxQojIA0GryArgnSYYtS9A6j2KQzsAhhrsN00+dW7d1SNxKTvsbzkJxAveYsMPtJQ21w=="],
 
-    "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
-
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
-
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
-
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
-
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
-
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
-
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
-
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
-
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
-
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
-
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
-
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
-
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
-
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
-
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
-
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
-
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
-
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
-
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q=="],
-
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
-
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow=="],
-
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
-
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg=="],
-
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
-
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
-
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
-
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@hono/mcp": ["@hono/mcp@0.2.5", "", { "dependencies": { "pkce-challenge": "^5.0.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.1", "hono": "*", "hono-rate-limiter": "^0.4.2", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-JsaJes7VlNvUrUQ9j2b9C13xjFLvyKQY515aWtsdJ9cwhBmWz5od2yUCbDu7cX38GeADmlLmpu4BKNNAV6G27w=="],
 
@@ -136,7 +80,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -146,41 +90,41 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
+    "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.11", "", { "os": "android", "cpu": "arm64" }, "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.11", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.11", "", { "os": "linux", "cpu": "arm" }, "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11", "", { "os": "linux", "cpu": "s390x" }, "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.11", "", { "os": "linux", "cpu": "x64" }, "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.11", "", { "os": "linux", "cpu": "x64" }, "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.11", "", { "os": "none", "cpu": "arm64" }, "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.11", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.11", "", { "os": "win32", "cpu": "x64" }, "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.11", "", {}, "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -212,15 +156,15 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
 
-    "@vue/compiler-core": ["@vue/compiler-core@3.5.30", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/shared": "3.5.30", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw=="],
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
 
-    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.30", "", { "dependencies": { "@vue/compiler-core": "3.5.30", "@vue/shared": "3.5.30" } }, "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g=="],
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
 
-    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.30", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/compiler-core": "3.5.30", "@vue/compiler-dom": "3.5.30", "@vue/compiler-ssr": "3.5.30", "@vue/shared": "3.5.30", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.8", "source-map-js": "^1.2.1" } }, "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A=="],
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.32", "@vue/compiler-dom": "3.5.32", "@vue/compiler-ssr": "3.5.32", "@vue/shared": "3.5.32", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.8", "source-map-js": "^1.2.1" } }, "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg=="],
 
-    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.30", "", { "dependencies": { "@vue/compiler-dom": "3.5.30", "@vue/shared": "3.5.30" } }, "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA=="],
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.32", "", { "dependencies": { "@vue/compiler-dom": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw=="],
 
-    "@vue/shared": ["@vue/shared@3.5.30", "", {}, "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ=="],
+    "@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -246,13 +190,13 @@
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
-    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -282,7 +226,9 @@
 
     "commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
-    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
@@ -338,8 +284,6 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
-    "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
-
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
@@ -352,7 +296,7 @@
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
-    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+    "eventsource-parser": ["eventsource-parser@3.0.7", "", {}, "sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA=="],
 
     "expand-tilde": ["expand-tilde@2.0.2", "", { "dependencies": { "homedir-polyfill": "^1.0.1" } }, "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw=="],
 
@@ -360,9 +304,9 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
-    "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
-    "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
+    "fast-copy": ["fast-copy@4.0.3", "", {}, "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -396,7 +340,7 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
-    "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -410,7 +354,7 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
@@ -500,7 +444,7 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -558,7 +502,7 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
-    "path-to-regexp": ["path-to-regexp@8.4.0", "", {}, "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg=="],
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
@@ -582,7 +526,7 @@
 
     "plimit-lit": ["plimit-lit@1.6.1", "", { "dependencies": { "queue-lit": "^1.5.1" } }, "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA=="],
 
-    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
@@ -590,7 +534,7 @@
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
-    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
     "queue-lit": ["queue-lit@1.5.2", "", {}, "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw=="],
 
@@ -612,7 +556,7 @@
 
     "require-package-name": ["require-package-name@2.0.1", "", {}, "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q=="],
 
-    "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
     "resolve-dir": ["resolve-dir@1.0.1", "", { "dependencies": { "expand-tilde": "^2.0.0", "global-modules": "^1.0.0" } }, "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg=="],
 
@@ -622,7 +566,7 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rolldown": ["rolldown@1.0.0-rc.11", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.11" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.11", "@rolldown/binding-darwin-arm64": "1.0.0-rc.11", "@rolldown/binding-darwin-x64": "1.0.0-rc.11", "@rolldown/binding-freebsd-x64": "1.0.0-rc.11", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw=="],
+    "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -650,7 +594,7 @@
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
-    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
 
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
@@ -672,7 +616,7 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -686,9 +630,9 @@
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
-    "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
+    "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
@@ -700,8 +644,6 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
-
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
@@ -712,7 +654,7 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
-    "vite": ["vite@8.0.2", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.11", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA=="],
+    "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 
     "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
 
@@ -734,7 +676,7 @@
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -753,5 +695,7 @@
     "multimatch/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "multimatch/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
   }
 }

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -1,14 +1,14 @@
 # congressgov-mcp-server - Directory Structure
 
-Generated on: 2026-03-24 10:51:49
+Generated on: 2026-04-18 13:10:23
 
 ```text
 congressgov-mcp-server/
+├── .agents/
 ├── .claude/
 ├── .vscode/
 │   ├── extensions.json
 │   └── settings.json
-├── claude-plans/
 ├── docs/
 │   └── congress-gov-mcp-design.md
 ├── scripts/
@@ -18,6 +18,8 @@ congressgov-mcp-server/
 │   ├── lint-mcp.ts
 │   └── tree.ts
 ├── skills/
+│   ├── add-app-tool/
+│   │   └── SKILL.md
 │   ├── add-prompt/
 │   │   └── SKILL.md
 │   ├── add-resource/
@@ -68,6 +70,10 @@ congressgov-mcp-server/
 │   │   │   ├── package-meta.md
 │   │   │   ├── readme.md
 │   │   │   └── server-json.md
+│   │   └── SKILL.md
+│   ├── report-issue-framework/
+│   │   └── SKILL.md
+│   ├── report-issue-local/
 │   │   └── SKILL.md
 │   └── setup/
 │       └── SKILL.md
@@ -135,6 +141,7 @@ congressgov-mcp-server/
 ├── .dockerignore
 ├── .env.example
 ├── .gitignore
+├── AGENTS.md
 ├── biome.json
 ├── bun.lock
 ├── bunfig.toml

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bin": {
     "congressgov-mcp-server": "dist/index.js"
   },
-  "files": ["dist/", "README.md", "LICENSE", "CLAUDE.md", "Dockerfile", "server.json"],
+  "files": ["dist/", "README.md", "LICENSE", "CLAUDE.md", "AGENTS.md", "Dockerfile", "server.json"],
   "scripts": {
     "build": "bun scripts/build.ts",
     "rebuild": "bun scripts/clean.ts && bun scripts/build.ts",
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@cyanheads/mcp-ts-core": "^0.2.10",
+    "@cyanheads/mcp-ts-core": "^0.3.5",
     "pino-pretty": "^13.1.3"
   },
   "overrides": {
@@ -73,12 +73,12 @@
     "path-to-regexp": ">=8.4.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.10",
-    "@types/node": "^25.5.0",
+    "@biomejs/biome": "^2.4.12",
+    "@types/node": "^25.6.0",
     "depcheck": "^1.4.7",
     "ignore": "^7.0.5",
     "tsc-alias": "^1.8.16",
-    "typescript": "^6.0.2",
-    "vitest": "^4.1.2"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyanheads/congressgov-mcp-server",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Access U.S. congressional data - bills, votes, members, committees - through MCP. STDIO & Streamable HTTP.",
   "mcpName": "io.github.cyanheads/congressgov-mcp-server",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -68,10 +68,6 @@
     "@cyanheads/mcp-ts-core": "^0.3.5",
     "pino-pretty": "^13.1.3"
   },
-  "overrides": {
-    "brace-expansion": ">=2.0.3",
-    "path-to-regexp": ">=8.4.0"
-  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",
     "@types/node": "^25.6.0",

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/cyanheads/congressgov-mcp-server",
     "source": "github"
   },
-  "version": "0.3.7",
+  "version": "0.3.8",
   "remotes": [
     {
       "type": "streamable-http",
@@ -19,7 +19,7 @@
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cyanheads/congressgov-mcp-server",
       "runtimeHint": "bun",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "packageArguments": [
         {
           "type": "positional",
@@ -54,7 +54,7 @@
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cyanheads/congressgov-mcp-server",
       "runtimeHint": "bun",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "packageArguments": [
         {
           "type": "positional",

--- a/skills/add-app-tool/SKILL.md
+++ b/skills/add-app-tool/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: add-app-tool
+description: >
+  Scaffold an MCP App tool + UI resource pair. Use when the user asks to add a tool with interactive UI, create an MCP App, or build a visual/interactive tool.
+metadata:
+  author: cyanheads
+  version: "1.2"
+  audience: external
+  type: reference
+---
+
+## Context
+
+MCP Apps extend the standard tool pattern with an interactive HTML UI rendered in a sandboxed iframe by the host. Each MCP App consists of two definitions:
+
+1. **App tool** (`.app-tool.ts`) — uses `appTool()` builder, declares `resourceUri` pointing to the UI resource
+2. **App resource** (`.app-resource.ts`) — uses `appResource()` builder, serves the bundled HTML
+
+Both builders are exported from `@cyanheads/mcp-ts-core`. They handle `_meta.ui.resourceUri`, the compat key (`ui/resourceUri`), and the correct MIME type (`text/html;profile=mcp-app`) automatically.
+
+For the full API, Context interface, and error codes, read:
+
+    node_modules/@cyanheads/mcp-ts-core/CLAUDE.md
+
+## Steps
+
+1. **Ask the user** for the tool's name, purpose, input/output shape, and what the UI should display
+2. **Choose a URI** — convention: `ui://{{tool-name}}/app.html`
+3. **Create the app tool** at `src/mcp-server/tools/definitions/{{tool-name}}.app-tool.ts`
+4. **Create the app resource** at `src/mcp-server/resources/definitions/{{tool-name}}-ui.app-resource.ts`
+5. **Register both** in the project's existing `createApp()` arrays (directly in `src/index.ts` for fresh scaffolds, or via barrels if the repo already has them)
+6. **Run `bun run devcheck`** — the linter validates `_meta.ui` and cross-checks tool/resource pairing
+7. **Smoke-test** with `bun run dev:stdio` or `dev:http`
+
+## App Tool Template
+
+```typescript
+/**
+ * @fileoverview {{TOOL_DESCRIPTION}}
+ * @module mcp-server/tools/definitions/{{TOOL_NAME}}.app-tool
+ */
+
+import { appTool, z } from '@cyanheads/mcp-ts-core';
+
+const UI_RESOURCE_URI = 'ui://{{tool-name}}/app.html';
+
+export const {{TOOL_EXPORT}} = appTool('{{tool_name}}', {
+  resourceUri: UI_RESOURCE_URI,
+  title: '{{TOOL_TITLE}}',
+  description: '{{TOOL_DESCRIPTION}}',
+  annotations: { readOnlyHint: true },
+  input: z.object({
+    // All fields need .describe(). Only JSON-Schema-serializable Zod types allowed.
+  }),
+  output: z.object({
+    // All fields need .describe(). Only JSON-Schema-serializable Zod types allowed.
+  }),
+  // auth: ['tool:{{tool_name}}:read'],
+
+  async handler(input, ctx) {
+    ctx.log.info('Processing', { /* relevant input fields */ });
+    return { /* output */ };
+  },
+
+  // format() serves dual purpose for app tools:
+  // 1. First text block: JSON for the UI (app.ontoolresult parses it)
+  // 2. Subsequent blocks: human-readable, content-complete fallback for non-app hosts and LLM context
+  format(result) {
+    return [
+      { type: 'text', text: JSON.stringify(result) },
+      { type: 'text', text: '/* human-readable summary with all LLM-needed fields */' },
+    ];
+  },
+});
+```
+
+## App Resource Template
+
+```typescript
+/**
+ * @fileoverview UI resource for {{TOOL_NAME}}.
+ * @module mcp-server/resources/definitions/{{TOOL_NAME}}-ui.app-resource
+ */
+
+import { appResource, z } from '@cyanheads/mcp-ts-core';
+
+const ParamsSchema = z.object({}).describe('No parameters. Returns the static HTML app.');
+
+const APP_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{TOOL_TITLE}}</title>
+  <style>/* your styles */</style>
+</head>
+<body>
+  <!-- your UI markup -->
+
+  <script type="module">
+    // Prefer a bundled or inlined SDK for the final shipped HTML. Leaving a live
+    // CDN import in the served ui:// resource is not the recommended default.
+    import {
+      App,
+      applyDocumentTheme,
+      applyHostFonts,
+      applyHostStyleVariables,
+    } from "https://unpkg.com/@modelcontextprotocol/ext-apps@1/app-with-deps";
+
+    const app = new App({ name: "{{TOOL_TITLE}}", version: "1.0.0" });
+
+    function applyHostContext(hostContext) {
+      if (hostContext?.theme) {
+        applyDocumentTheme(hostContext.theme);
+      }
+      if (hostContext?.styles?.variables) {
+        applyHostStyleVariables(hostContext.styles.variables);
+      }
+      if (hostContext?.styles?.css?.fonts) {
+        applyHostFonts(hostContext.styles.css.fonts);
+      }
+    }
+
+    // Receive initial tool result from the host
+    app.ontoolresult = (result) => {
+      const text = result.content?.find(c => c.type === "text")?.text;
+      if (!text) return;
+      const data = JSON.parse(text);
+      // render data into the DOM
+    };
+    app.onhostcontextchanged = applyHostContext;
+
+    // Proactively call tools from the UI
+    document.getElementById("action-btn").addEventListener("click", async () => {
+      const result = await app.callServerTool({
+        name: "{{tool_name}}",
+        arguments: { /* input */ },
+      });
+      // handle result
+    });
+
+    app.connect().then(() => {
+      const hostContext = app.getHostContext();
+      if (hostContext) applyHostContext(hostContext);
+    });
+  </script>
+</body>
+</html>`;
+
+export const {{RESOURCE_EXPORT}} = appResource('ui://{{tool-name}}/app.html', {
+  name: '{{tool-name}}-ui',
+  title: '{{TOOL_TITLE}} UI',
+  description: 'Interactive HTML app for {{tool_name}}.',
+  params: ParamsSchema,
+  // auth: ['resource:{{tool-name}}-ui:read'],
+  _meta: {
+    ui: {
+      csp: { resourceDomains: ['https://unpkg.com'] },
+    },
+  },
+
+  handler(_params, ctx) {
+    ctx.log.debug('Serving app UI.', { resourceUri: ctx.uri?.href });
+    return APP_HTML;
+  },
+
+  list: () => ({
+    resources: [
+      {
+        uri: 'ui://{{tool-name}}/app.html',
+        name: '{{TOOL_TITLE}}',
+        description: 'Interactive UI for {{tool_name}}.',
+      },
+    ],
+  }),
+});
+```
+
+## UI Design Notes
+
+- **Bundling:** Prefer Vite + `vite-plugin-singlefile` for any UI that uses `@modelcontextprotocol/ext-apps`. The served `ui://` HTML should ideally be self-contained. The inline template literal pattern is fine for zero-dependency UIs or when you inline the SDK yourself.
+- **Client-side SDK:** Author against `@modelcontextprotocol/ext-apps`, but ship a bundled or inlined artifact when possible. Avoid relying on a live CDN import as the default final pattern for portable host compatibility.
+- **CSP:** MCP Apps iframes run under deny-by-default CSP. With `appResource()`, put `_meta.ui.csp.resourceDomains` on the definition and the builder will mirror it into returned `resources/read` content items. With plain `resource()`, you still need to attach `_meta.ui` yourself in `format()`.
+- **App resource `format()`:** `appResource()` already preserves raw HTML for the default app MIME type and mirrors definition `_meta.ui` into content items. Add a custom `format()` only when you need extra per-read metadata or non-default content shaping.
+- **format() for app tools:** The first `text` content block is typically JSON that the UI parses via `ontoolresult`. Additional blocks provide a human-readable fallback that non-app hosts and LLMs consume. Do not rely on the JSON block alone for model-visible detail; the fallback blocks still need to render the fields the LLM must reason about.
+
+## Registration
+
+```typescript
+// src/index.ts (fresh scaffold default)
+import { createApp } from '@cyanheads/mcp-ts-core';
+import { {{TOOL_EXPORT}} } from './mcp-server/tools/definitions/{{tool-name}}.app-tool.js';
+import { {{RESOURCE_EXPORT}} } from './mcp-server/resources/definitions/{{tool-name}}-ui.app-resource.js';
+
+await createApp({
+  tools: [{{TOOL_EXPORT}}],
+  resources: [{{RESOURCE_EXPORT}}],
+  prompts: [/* existing prompts */],
+});
+```
+
+If the repo already uses `definitions/index.ts` barrels, update those instead of changing the registration pattern.
+
+## Checklist
+
+- [ ] App tool created at `src/mcp-server/tools/definitions/{{tool-name}}.app-tool.ts` using `appTool()`
+- [ ] App resource created at `src/mcp-server/resources/definitions/{{tool-name}}-ui.app-resource.ts` using `appResource()`
+- [ ] `resourceUri` matches between tool and resource (`ui://{{tool-name}}/app.html`)
+- [ ] Zod schemas: all fields have `.describe()`, only JSON-Schema-serializable types
+- [ ] `format()` renders JSON first block (for UI) + human-readable, content-complete fallback blocks (for non-app hosts and LLMs)
+- [ ] App resource `_meta.ui.csp` covers any external iframe dependencies, or a custom `format()` adds equivalent per-read metadata
+- [ ] UI bundles or inlines the client SDK for the shipped HTML, and handles `app.ontoolresult`
+- [ ] UI applies host context updates via `app.onhostcontextchanged`
+- [ ] Both registered in the project's existing `createApp()` arrays (directly or via barrels)
+- [ ] `bun run devcheck` passes (linter validates `_meta.ui` and tool/resource pairing)
+- [ ] Smoke-tested with `bun run dev:stdio` or `dev:http`

--- a/skills/add-prompt/SKILL.md
+++ b/skills/add-prompt/SKILL.md
@@ -4,14 +4,14 @@ description: >
   Scaffold a new MCP prompt template. Use when the user asks to add a prompt, create a reusable message template, or define a prompt for LLM interactions.
 metadata:
   author: cyanheads
-  version: "1.0"
+  version: "1.1"
   audience: external
   type: reference
 ---
 
 ## Context
 
-Prompts use the `prompt()` builder from `@cyanheads/mcp-ts-core`. Each prompt lives in `src/mcp-server/prompts/definitions/` with a `.prompt.ts` suffix and is registered in the barrel `index.ts`.
+Prompts use the `prompt()` builder from `@cyanheads/mcp-ts-core`. Each prompt lives in `src/mcp-server/prompts/definitions/` with a `.prompt.ts` suffix and is registered into `createApp()` in `src/index.ts`. Some repos later add `definitions/index.ts` barrels; match the project's current pattern.
 
 Prompts are pure message templates — no `Context`, no auth, no side effects.
 
@@ -23,7 +23,7 @@ For the full `prompt()` API, read:
 
 1. **Ask the user** for the prompt's name, purpose, and arguments
 2. **Create the file** at `src/mcp-server/prompts/definitions/{{prompt-name}}.prompt.ts`
-3. **Register** the prompt in `src/mcp-server/prompts/definitions/index.ts`
+3. **Register** the prompt in the project's existing `createApp()` prompt list (directly in `src/index.ts` for fresh scaffolds, or via a barrel if the repo already has one)
 4. **Run `bun run devcheck`** to verify
 
 ## Template
@@ -74,16 +74,21 @@ generate: (args) => [
 ],
 ```
 
-### Barrel registration
+### Registration
 
 ```typescript
-// src/mcp-server/prompts/definitions/index.ts
-import { {{PROMPT_EXPORT}} } from './{{prompt-name}}.prompt.js';
-export const allPromptDefinitions = [
-  // ... existing prompts
-  {{PROMPT_EXPORT}},
-];
+// src/index.ts (fresh scaffold default)
+import { createApp } from '@cyanheads/mcp-ts-core';
+import { {{PROMPT_EXPORT}} } from './mcp-server/prompts/definitions/{{prompt-name}}.prompt.js';
+
+await createApp({
+  tools: [/* existing tools */],
+  resources: [/* existing resources */],
+  prompts: [{{PROMPT_EXPORT}}],
+});
 ```
+
+If the repo already uses `src/mcp-server/prompts/definitions/index.ts`, update that barrel instead.
 
 ## Checklist
 
@@ -92,5 +97,5 @@ export const allPromptDefinitions = [
 - [ ] JSDoc `@fileoverview` and `@module` header present
 - [ ] `generate` function returns valid message array
 - [ ] No side effects — prompts are pure templates
-- [ ] Registered in `definitions/index.ts` barrel and `allPromptDefinitions`
+- [ ] Registered in the project's existing `createApp()` prompt list (directly or via barrel)
 - [ ] `bun run devcheck` passes

--- a/skills/add-resource/SKILL.md
+++ b/skills/add-resource/SKILL.md
@@ -4,14 +4,14 @@ description: >
   Scaffold a new MCP resource definition. Use when the user asks to add a resource, expose data via URI, or create a readable endpoint.
 metadata:
   author: cyanheads
-  version: "1.1"
+  version: "1.2"
   audience: external
   type: reference
 ---
 
 ## Context
 
-Resources use the `resource()` builder from `@cyanheads/mcp-ts-core`. Each resource lives in `src/mcp-server/resources/definitions/` with a `.resource.ts` suffix and is registered in the barrel `index.ts`.
+Resources use the `resource()` builder from `@cyanheads/mcp-ts-core`. Each resource lives in `src/mcp-server/resources/definitions/` with a `.resource.ts` suffix and is registered into `createApp()` in `src/index.ts`. Some repos later add `definitions/index.ts` barrels; follow the pattern already used by the project.
 
 **Tool coverage.** Not all MCP clients expose resources — many are tool-only (Claude Code, Cursor, most chat UIs). Before adding a resource, verify the same data is reachable via the tool surface — either through a dedicated tool, included in another tool's output, or bundled into a broader tool. A resource whose data has no tool path is invisible to a large share of agents.
 
@@ -24,7 +24,7 @@ For the full `resource()` API, pagination utilities, and `Context` interface, re
 1. **Ask the user** for the resource's URI template, purpose, and data shape
 2. **Design the URI** — use `{paramName}` for path parameters (e.g., `myscheme://{itemId}/data`)
 3. **Create the file** at `src/mcp-server/resources/definitions/{{resource-name}}.resource.ts`
-4. **Register** the resource in `src/mcp-server/resources/definitions/index.ts`
+4. **Register** the resource in the project's existing `createApp()` resource list (directly in `src/index.ts` for fresh scaffolds, or via a barrel if the repo already has one)
 5. **Run `bun run devcheck`** to verify
 6. **Smoke-test** with `bun run dev:stdio` or `dev:http`
 
@@ -41,6 +41,7 @@ import { resource, z } from '@cyanheads/mcp-ts-core';
 export const {{RESOURCE_EXPORT}} = resource('{{scheme}}://{{{paramName}}}/data', {
   description: '{{RESOURCE_DESCRIPTION}}',
   mimeType: 'application/json',
+  // size: 1024,  // optional: content size in bytes, if known
   params: z.object({
     {{paramName}}: z.string().describe('{{PARAM_DESCRIPTION}}'),
   }),
@@ -92,16 +93,21 @@ async handler(params, ctx) {
 },
 ```
 
-### Barrel registration
+### Registration
 
 ```typescript
-// src/mcp-server/resources/definitions/index.ts
-import { {{RESOURCE_EXPORT}} } from './{{resource-name}}.resource.js';
-export const allResourceDefinitions = [
-  // ... existing resources
-  {{RESOURCE_EXPORT}},
-];
+// src/index.ts (fresh scaffold default)
+import { createApp } from '@cyanheads/mcp-ts-core';
+import { {{RESOURCE_EXPORT}} } from './mcp-server/resources/definitions/{{resource-name}}.resource.js';
+
+await createApp({
+  tools: [/* existing tools */],
+  resources: [{{RESOURCE_EXPORT}}],
+  prompts: [/* existing prompts */],
+});
 ```
+
+If the repo already uses `src/mcp-server/resources/definitions/index.ts`, update that barrel instead of changing the registration style.
 
 ## Checklist
 
@@ -113,6 +119,6 @@ export const allResourceDefinitions = [
 - [ ] Data is reachable via the tool surface (dedicated tool, another tool's output, or not needed for tool-only agents)
 - [ ] `list()` function provided if the resource is discoverable
 - [ ] Pagination used for large result sets (`extractCursor`/`paginateArray`)
-- [ ] Registered in `definitions/index.ts` barrel and `allResourceDefinitions`
+- [ ] Registered in the project's existing `createApp()` resource list (directly or via barrel)
 - [ ] `bun run devcheck` passes
 - [ ] Smoke-tested with `bun run dev:stdio` or `dev:http`

--- a/skills/add-service/SKILL.md
+++ b/skills/add-service/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Scaffold a new service integration. Use when the user asks to add a service, integrate an external API, or create a reusable domain module with its own initialization and state.
 metadata:
   author: cyanheads
-  version: "1.0"
+  version: "1.2"
   audience: external
   type: reference
 ---
@@ -25,7 +25,7 @@ For the full service pattern, `CoreServices`, and `Context` interface, read:
 2. **Create the directory** at `src/services/{{domain}}/`
 3. **Create the service file** at `src/services/{{domain}}/{{domain}}-service.ts`
 4. **Create types** at `src/services/{{domain}}/types.ts` if needed
-5. **Register in `setup()`** in the server's entry point (`src/index.ts`)
+5. **Register in `setup()`** in the server's entry point (`src/index.ts`, or `src/worker.ts` for Worker-only servers)
 6. **Run `bun run devcheck`** to verify
 
 ## Template
@@ -79,9 +79,9 @@ import { createApp } from '@cyanheads/mcp-ts-core';
 import { init{{ServiceName}} } from './services/{{domain}}/{{domain}}-service.js';
 
 await createApp({
-  tools: allToolDefinitions,
-  resources: allResourceDefinitions,
-  prompts: allPromptDefinitions,
+  tools: [/* existing tools */],
+  resources: [/* existing resources */],
+  prompts: [/* existing prompts */],
   setup(core) {
     init{{ServiceName}}(core.config, core.storage);
   },
@@ -98,6 +98,132 @@ handler: async (input, ctx) => {
 },
 ```
 
+## Resilience (External API Services)
+
+When a service wraps an external API, apply these patterns. For the framework retry contract, see `skills/api-utils/SKILL.md`.
+
+### Retry wraps the full pipeline
+
+Place retry at the service method level — covering both HTTP fetch and response parsing/validation. The HTTP client should be single-attempt; the service owns retry. Use `withRetry` from `@cyanheads/mcp-ts-core/utils`:
+
+```typescript
+import { withRetry, fetchWithTimeout } from '@cyanheads/mcp-ts-core/utils';
+import type { Context } from '@cyanheads/mcp-ts-core';
+
+async fetchItem(id: string, ctx: Context): Promise<Item> {
+  return withRetry(
+    async () => {
+      const response = await fetchWithTimeout(
+        `${this.baseUrl}/items/${id}`,
+        10_000,
+        ctx,
+      );
+      const text = await response.text();
+      return this.parseResponse<Item>(text);
+    },
+    {
+      operation: 'fetchItem',
+      context: ctx,
+      baseDelayMs: 1000,    // calibrate to upstream recovery time
+      signal: ctx.signal,
+    },
+  );
+}
+```
+
+### Key principles
+
+1. **Calibrate backoff to the upstream.** 200–500ms for ephemeral failures, 1–2s for rate-limited APIs, 2–5s for service degradation. The default `baseDelayMs: 1000` suits most APIs.
+2. **Check HTTP status before parsing.** `fetchWithTimeout` already throws `ServiceUnavailable` on non-OK responses — this prevents feeding HTML error pages into XML/JSON parsers.
+3. **Classify parse failures by content.** If the upstream returns HTTP 200 with an HTML error page, detect it and throw `ServiceUnavailable` (transient) instead of `SerializationError` (non-transient).
+4. **Exhausted retries say so.** `withRetry` automatically enriches the final error with attempt count — callers know retries were already attempted.
+
+### Response handler pattern
+
+```typescript
+parseResponse<T>(text: string): T {
+  // Detect HTML error pages masquerading as successful responses
+  if (/^\s*<(!DOCTYPE\s+html|html[\s>])/i.test(text)) {
+    throw serviceUnavailable('API returned HTML instead of expected format — likely rate-limited.');
+  }
+  // Parse and validate...
+}
+```
+
+### Sparse upstream payloads
+
+Third-party APIs often omit fields entirely instead of returning `null`. If your raw response types, normalized domain types, or tool output schemas are stricter than the real upstream payloads, you'll either fail validation or silently invent facts.
+
+**Guidance:**
+
+1. **Raw upstream types default to optional unless presence is guaranteed.** Trust the docs only after you've verified real payloads.
+2. **Preserve absence when it means "unknown".** Missing data is different from `false`, `0`, `''`, or an empty array.
+3. **Don't fabricate defaults during normalization** unless the upstream contract or your own tool semantics explicitly define them.
+4. **With `exactOptionalPropertyTypes`, omit absent fields instead of returning `undefined`.** Conditional spreads keep the normalized object honest.
+
+```typescript
+type RawRepo = {
+  id: string;
+  name: string;
+  archived?: boolean;
+  star_count?: number;
+  description?: string | null;
+};
+
+type Repo = {
+  id: string;
+  name: string;
+  archived?: boolean;
+  starCount?: number;
+  description?: string;
+};
+
+function normalizeRepo(raw: RawRepo): Repo {
+  const description = raw.description?.trim();
+  return {
+    id: raw.id,
+    name: raw.name,
+    ...(typeof raw.archived === 'boolean' && { archived: raw.archived }),
+    ...(typeof raw.star_count === 'number' && { starCount: raw.star_count }),
+    ...(description ? { description } : {}),
+  };
+}
+```
+
+## API Efficiency
+
+When a service wraps an external API, design methods to minimize upstream calls. These patterns compound — a tool calling 3 service methods that each make N requests is 3N calls; batching drops it to 3.
+
+### Batch over N+1
+
+If the API supports filter-by-IDs, bulk GET, or batch query endpoints, expose a batch method instead of (or alongside) the single-item method. One request for 20 items beats 20 sequential requests — it eliminates serial latency, avoids rate-limit accumulation, and simplifies error handling.
+
+```typescript
+/** Fetch multiple studies in a single request via filter.ids. */
+async getStudiesBatch(nctIds: string[], ctx: Context): Promise<Study[]> {
+  const response = await this.searchStudies({
+    filterIds: nctIds,
+    fields: ['NCTId', 'BriefTitle', 'HasResults', 'ResultsSection'],
+    pageSize: nctIds.length,
+  }, ctx);
+  return response.studies;
+}
+```
+
+Cross-reference the response against the requested IDs to detect missing items — don't assume the API returns everything you asked for.
+
+### Field selection
+
+If the API supports `fields`, `select`, or `include` parameters, request only what the caller needs. A full record might be 70KB; four fields might be 5KB. Expose field selection as a parameter on the service method, or use sensible defaults per method.
+
+### Pagination awareness
+
+If a batch request might exceed the API's page size limit, either:
+- Paginate internally (loop until all pages consumed), or
+- Assert/throw when the response indicates truncation (e.g., `nextPageToken` present)
+
+Silent truncation is a data integrity bug — the caller thinks it has all results when it doesn't.
+
 ## Checklist
 
 - [ ] Directory created at `src/services/{{domain}}/`
@@ -106,4 +232,7 @@ handler: async (input, ctx) => {
 - [ ] Service methods accept `Context` for logging and storage
 - [ ] `init` function registered in `setup()` callback in `src/index.ts`
 - [ ] Accessor throws `Error` if not initialized
+- [ ] If wrapping external API: retry covers full pipeline (fetch + parse), backoff calibrated
+- [ ] If wrapping external API: raw/domain types reflect real upstream sparsity; missing values are preserved as unknown, not fabricated into concrete facts
+- [ ] If wrapping external API: batch endpoints used where available, field selection applied, pagination handled
 - [ ] `bun run devcheck` passes

--- a/skills/add-test/SKILL.md
+++ b/skills/add-test/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: add-test
 description: >
-  Scaffold a test file for an existing tool, resource, or service. Use when the user asks to add tests, improve coverage, or when a definition exists without a colocated test file.
+  Scaffold a test file for an existing tool, resource, or service. Use when the user asks to add tests, improve coverage, or when a definition exists without a matching test file.
 metadata:
   author: cyanheads
-  version: "1.0"
+  version: "1.3"
   audience: external
   type: reference
 ---
 
 ## Context
 
-Tests use Vitest and `createMockContext` from `@cyanheads/mcp-ts-core/testing`. Test files are colocated with their source: `foo.tool.ts` gets `foo.tool.test.ts` in the same directory.
+Tests use Vitest and `createMockContext` from `@cyanheads/mcp-ts-core/testing`. If the repo already has tests, match the existing layout. If the repo has no existing tests, create a root `tests/` directory that mirrors the `src/` structure (e.g. `tests/mcp-server/tools/definitions/echo.tool.test.ts` for `src/mcp-server/tools/definitions/echo.tool.ts`).
 
 For the full `createMockContext` API and testing patterns, read:
 
@@ -21,9 +21,9 @@ For the full `createMockContext` API and testing patterns, read:
 
 1. **Identify the target** — which tool, resource, or service needs tests
 2. **Read the source file** — understand the handler's logic, input/output schemas, error paths, and which `ctx` features it uses
-3. **Create the test file** colocated with the source
+3. **Create the test file** in the repo's existing test layout
 4. **Write test cases** covering happy path, error paths, and edge cases
-5. **Run `npm test`** to verify
+5. **Run `bun run test`** to verify
 6. **Run `bun run devcheck`** to verify types
 
 ## Determining What to Test
@@ -38,7 +38,8 @@ Read the handler and identify:
 | **`ctx.state` usage** | Use `createMockContext({ tenantId: 'test' })` to enable storage |
 | **`ctx.elicit` / `ctx.sample`** | Mock with `vi.fn()`, also test the absent case (undefined) |
 | **`ctx.progress`** | Use `createMockContext({ progress: true })` for task tools |
-| **`format` function** | Test separately if defined — it's pure, no ctx needed |
+| **`format` function** | Test separately if defined — it's pure, no ctx needed. Verify it renders the IDs and fields the model needs, not just a count or title. For projection-style tools, test non-default field selections. |
+| **Sparse upstream payloads** | For third-party API integrations, build a fixture with omitted fields. Assert normalized output still validates and `format()` preserves unknown values instead of inventing facts. |
 | **Auth scopes** | Not tested at handler level (framework enforces) — skip |
 
 ## Templates
@@ -48,12 +49,12 @@ Read the handler and identify:
 ```typescript
 /**
  * @fileoverview Tests for {{TOOL_NAME}} tool.
- * @module mcp-server/tools/definitions/{{TOOL_NAME}}.test
+ * @module tests/tools/{{TOOL_NAME}}.tool.test
  */
 
 import { describe, expect, it } from 'vitest';
 import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
-import { {{TOOL_EXPORT}} } from './{{tool-name}}.tool.js';
+import { {{TOOL_EXPORT}} } from '@/mcp-server/tools/definitions/{{tool-name}}.tool.js';
 
 describe('{{TOOL_EXPORT}}', () => {
   it('returns expected output for valid input', async () => {
@@ -75,11 +76,11 @@ describe('{{TOOL_EXPORT}}', () => {
     await expect({{TOOL_EXPORT}}.handler(input, ctx)).rejects.toThrow();
   });
 
-  it('formats output correctly', () => {
+  it('formats output completely', () => {
     const output = { /* mock output matching the output schema */ };
     const blocks = {{TOOL_EXPORT}}.format!(output);
-    expect(blocks).toHaveLength(1);
-    expect(blocks[0].type).toBe('text');
+    expect(blocks.some((block) => block.type === 'text')).toBe(true);
+    // Assert the rendered text includes the IDs/fields the LLM needs to act on.
   });
 });
 ```
@@ -89,12 +90,12 @@ describe('{{TOOL_EXPORT}}', () => {
 ```typescript
 /**
  * @fileoverview Tests for {{RESOURCE_NAME}} resource.
- * @module mcp-server/resources/definitions/{{RESOURCE_NAME}}.test
+ * @module tests/resources/{{RESOURCE_NAME}}.resource.test
  */
 
 import { describe, expect, it } from 'vitest';
 import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
-import { {{RESOURCE_EXPORT}} } from './{{resource-name}}.resource.js';
+import { {{RESOURCE_EXPORT}} } from '@/mcp-server/resources/definitions/{{resource-name}}.resource.js';
 
 describe('{{RESOURCE_EXPORT}}', () => {
   it('returns data for valid params', async () => {
@@ -131,16 +132,16 @@ describe('{{RESOURCE_EXPORT}}', () => {
 ```typescript
 /**
  * @fileoverview Tests for {{SERVICE_NAME}} service.
- * @module services/{{domain}}/{{SERVICE_NAME}}.test
+ * @module tests/services/{{domain}}/{{domain}}-service.test
  */
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
-import { init{{ServiceClass}}, get{{ServiceClass}} } from './{{service-name}}-service.js';
+import { get{{ServiceClass}}, init{{ServiceClass}} } from '@/services/{{domain}}/{{domain}}-service.js';
 
 describe('{{ServiceClass}}', () => {
   beforeEach(() => {
-    // Re-initialize with fresh config/storage per suite
+    // Re-initialize with fresh config/storage for each test
     init{{ServiceClass}}(mockConfig, mockStorage);
   });
 
@@ -150,14 +151,10 @@ describe('{{ServiceClass}}', () => {
     const result = await service.doWork('input', ctx);
     expect(result).toBeDefined();
   });
-
-  it('throws when not initialized', () => {
-    // Reset the singleton — this is the only case where accessing
-    // the module internals is acceptable
-    expect(() => get{{ServiceClass}}()).toThrow(/not initialized/);
-  });
 });
 ```
+
+If you need to test the accessor's "not initialized" guard, do it in a separate isolated-module test (`vi.resetModules()` before importing the service module). Don't mix that assertion into a suite that already calls `init{{ServiceClass}}()` in `beforeEach()`.
 
 ### Task tool test
 
@@ -202,15 +199,17 @@ When scaffolding tests for an existing handler, use the Zod schemas to generate 
 4. **Defaults** — omit optional fields, verify defaults are applied in the output
 5. **Boundaries** — if the schema has `.min()`, `.max()`, `.length()`, test at the boundaries
 6. **Error paths** — trace the handler logic for throw conditions, construct inputs that trigger each
+7. **Sparse upstream fixtures** — if the handler/service wraps a third-party API, add at least one fixture where upstream omits optional fields entirely. Assert that the output still validates and that `format()` renders uncertainty honestly (`Not available`, omitted badge, etc.) instead of fabricating values.
 
 ## Checklist
 
-- [ ] Test file created at `src/.../{{name}}.test.ts` (colocated with source)
+- [ ] Test file created in the repo's existing layout (`tests/...` or colocated with source)
 - [ ] JSDoc `@fileoverview` and `@module` header present
 - [ ] Happy path tested with valid input → expected output
 - [ ] Error paths tested (at least one `.rejects.toThrow()`)
 - [ ] `format` function tested if defined
 - [ ] `createMockContext` options match handler's ctx usage (`tenantId`, `progress`, `elicit`, `sample`)
 - [ ] Service re-initialized in `beforeEach` if handler depends on a service singleton
-- [ ] `npm test` passes
+- [ ] If wrapping external API: sparse-payload case tested (omitted upstream fields still validate; `format()` does not invent facts)
+- [ ] `bun run test` passes
 - [ ] `bun run devcheck` passes

--- a/skills/add-tool/SKILL.md
+++ b/skills/add-tool/SKILL.md
@@ -4,14 +4,14 @@ description: >
   Scaffold a new MCP tool definition. Use when the user asks to add a tool, create a new tool, or implement a new capability for the server.
 metadata:
   author: cyanheads
-  version: "1.1"
+  version: "1.3"
   audience: external
   type: reference
 ---
 
 ## Context
 
-Tools use the `tool()` builder from `@cyanheads/mcp-ts-core`. Each tool lives in `src/mcp-server/tools/definitions/` with a `.tool.ts` suffix and is registered in the barrel `index.ts`.
+Tools use the `tool()` builder from `@cyanheads/mcp-ts-core`. Each tool lives in `src/mcp-server/tools/definitions/` with a `.tool.ts` suffix and is registered into `createApp()` in `src/index.ts`. Some larger repos later add `definitions/index.ts` barrels; match the pattern already used by the project you're editing.
 
 For the full `tool()` API, `Context` interface, and error codes, read:
 
@@ -23,7 +23,7 @@ For the full `tool()` API, `Context` interface, and error codes, read:
 2. **Determine if long-running** — if the tool involves streaming, polling, or
    multi-step async work, it should use `task: true`
 3. **Create the file** at `src/mcp-server/tools/definitions/{{tool-name}}.tool.ts`
-4. **Register** the tool in `src/mcp-server/tools/definitions/index.ts`
+4. **Register** the tool in the project's existing `createApp()` tool list (directly in `src/index.ts` for fresh scaffolds, or via a barrel if the repo already has one)
 5. **Run `bun run devcheck`** to verify
 6. **Smoke-test** with `bun run dev:stdio` or `dev:http`
 
@@ -96,18 +96,22 @@ export const {{TOOL_EXPORT}} = tool('{{tool_name}}', {
 });
 ```
 
-### Barrel registration
+### Registration
 
 ```typescript
-// src/mcp-server/tools/definitions/index.ts
-import { existingTool } from './existing-tool.tool.js';
-import { {{TOOL_EXPORT}} } from './{{tool-name}}.tool.js';
+// src/index.ts (fresh scaffold default)
+import { createApp } from '@cyanheads/mcp-ts-core';
+import { existingTool } from './mcp-server/tools/definitions/existing-tool.tool.js';
+import { {{TOOL_EXPORT}} } from './mcp-server/tools/definitions/{{tool-name}}.tool.js';
 
-export const allToolDefinitions = [
-  existingTool,
-  {{TOOL_EXPORT}},
-];
+await createApp({
+  tools: [existingTool, {{TOOL_EXPORT}}],
+  resources: [/* existing resources */],
+  prompts: [/* existing prompts */],
+});
 ```
+
+If the repo already uses `src/mcp-server/tools/definitions/index.ts`, update that barrel instead of switching patterns midstream.
 
 ## Tool Response Design
 
@@ -177,6 +181,43 @@ if (results.length === 0) {
 }
 ```
 
+### Sparse upstream data must stay honest
+
+When tool output comes from a third-party API, don't overstate certainty. Upstream systems often omit fields entirely; the tool schema and `format()` should preserve that uncertainty instead of collapsing it into fake `false`, `0`, or empty-string facts.
+
+**Guidance:**
+
+- Use optional output fields when the upstream source is sparse.
+- Render unknown values explicitly (`Not available`, `Unknown`) instead of inventing a concrete value.
+- Only render booleans, badges, counts, and summary facts when they are actually known.
+
+```typescript
+output: z.object({
+  repos: z.array(z.object({
+    id: z.string().describe('Repository ID.'),
+    name: z.string().describe('Repository name.'),
+    archived: z.boolean().optional()
+      .describe('Archived status when provided by the upstream API. Omitted when unknown.'),
+    stars: z.number().optional()
+      .describe('Star count when provided by the upstream API. Omitted when unknown.'),
+  })).describe('Repositories returned by the search.'),
+}),
+
+format: (result) => [{
+  type: 'text',
+  text: result.repos.map((repo) => [
+    `## ${repo.name}`,
+    `**ID:** ${repo.id}`,
+    typeof repo.archived === 'boolean'
+      ? `**Archived:** ${repo.archived ? 'Yes' : 'No'}`
+      : '**Archived:** Not available',
+    repo.stars != null
+      ? `**Stars:** ${repo.stars}`
+      : '**Stars:** Not available',
+  ].join('\n')).join('\n\n'),
+}],
+```
+
 ### Error classification and messaging
 
 The framework auto-classifies many errors at runtime (HTTP status codes, JS error types, common patterns). Use explicit error factories when you want a specific code and clear recovery guidance; plain `throw new Error()` when auto-classification is sufficient.
@@ -222,6 +263,37 @@ return {
 };
 ```
 
+### Defend against empty values from form-based clients
+
+LLM clients (Claude, Cursor, etc.) only send populated fields. **Form-based clients** (MCP Inspector, web UIs) submit the full schema shape — optional object fields arrive with empty-string inner values instead of `undefined`. Zod's `.optional()` only rejects `undefined`, so `{ minDate: "", maxDate: "" }` passes validation and reaches the handler.
+
+**Don't reject empty strings on optional fields** — that punishes form clients for valid MCP behavior. Instead, guard for meaningful values in the handler:
+
+```typescript
+// Schema: keep permissive — accepts empty strings from form clients
+input: z.object({
+  query: z.string().describe('Search terms'),
+  dateRange: z.object({
+    minDate: z.string().describe('Start date (YYYY-MM-DD)'),
+    maxDate: z.string().describe('End date (YYYY-MM-DD)'),
+  }).optional().describe('Restrict results to a date range.'),
+}),
+
+// Handler: check for meaningful values, not just object presence
+async handler(input, ctx) {
+  const params: Record<string, string> = { query: input.query };
+  if (input.dateRange?.minDate && input.dateRange?.maxDate) {
+    params.minDate = input.dateRange.minDate;
+    params.maxDate = input.dateRange.maxDate;
+  }
+  // ...
+},
+```
+
+The same applies to optional arrays — use `?.length` guards so empty arrays are skipped, not passed through.
+
+**Required fields are different.** If a string field is required and must be non-empty to be meaningful, `.min(1)` is correct — the client shouldn't have submitted the form without filling it in.
+
 ### Match response density to context budget
 
 Large payloads burn the agent's context window. Default to curated summaries; offer full data via opt-in parameters.
@@ -236,10 +308,12 @@ Large payloads burn the agent's context window. Default to curated summaries; of
 - [ ] All Zod schema fields have `.describe()` annotations
 - [ ] Schemas use only JSON-Schema-serializable types (no `z.custom()`, `z.date()`, `z.transform()`, `z.bigint()`, `z.symbol()`, `z.void()`, `z.map()`, `z.set()`)
 - [ ] JSDoc `@fileoverview` and `@module` header present
+- [ ] Optional nested objects guarded for empty inner values from form-based clients (check `?.field` truthiness, not just object presence)
 - [ ] `handler(input, ctx)` is pure — throws on failure, no try/catch
 - [ ] `format()` renders all data the LLM needs (not just a count or title) — `content[]` is the only field most clients forward to the model
+- [ ] If wrapping external API: output schema and `format()` preserve uncertainty from sparse upstream payloads instead of inventing concrete values
 - [ ] `auth` scopes declared if the tool needs authorization
 - [ ] `task: true` added if the tool is long-running
-- [ ] Registered in `definitions/index.ts` barrel and `allToolDefinitions`
+- [ ] Registered in the project's existing `createApp()` tool list (directly or via barrel)
 - [ ] `bun run devcheck` passes
 - [ ] Smoke-tested with `bun run dev:stdio` or `dev:http`

--- a/skills/api-testing/SKILL.md
+++ b/skills/api-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Testing patterns for MCP tool/resource handlers using `createMockContext` and Vitest. Covers mock context options, handler testing, McpError assertions, format testing, Vitest config setup, and test isolation conventions.
 metadata:
   author: cyanheads
-  version: "1.0"
+  version: "1.2"
   audience: external
   type: reference
 ---
@@ -13,7 +13,7 @@ metadata:
 
 Tests target handler behavior directly — call `handler(input, ctx)`, assert on the return value or thrown error. The framework's handler factory (try/catch, formatting, telemetry) is not involved. Use `createMockContext` from `@cyanheads/mcp-ts-core/testing` to construct the `ctx` argument.
 
-**Philosophy:** Test behavior, not implementation. Refactors should not break tests. Colocate test files with source (`foo.tool.ts` → `foo.tool.test.ts`). Integration tests at I/O boundaries over unit tests of internals.
+**Philosophy:** Test behavior, not implementation. Refactors should not break tests. Match the repo's existing test layout: fresh scaffolds use `tests/`, while colocated `src/**/*.test.ts` files are also supported. Integration tests at I/O boundaries over unit tests of internals.
 
 ---
 
@@ -28,8 +28,10 @@ createMockContext({ sample: vi.fn().mockResolvedValue(...) }) // with MCP sampli
 createMockContext({ elicit: vi.fn().mockResolvedValue(...) }) // with elicitation
 createMockContext({ progress: true })                        // with task progress (ctx.progress populated)
 createMockContext({ requestId: 'my-id' })                    // override request ID (default: 'test-request-id')
+createMockContext({ notifyResourceListChanged: () => {} })   // with resource-list change notifier
+createMockContext({ notifyResourceUpdated: (_uri) => {} })   // with resource update notifier
 createMockContext({ signal: controller.signal })             // custom AbortSignal
-createMockContext({ auth: { clientId: 'test', scopes: [] } }) // with auth context
+createMockContext({ auth: { clientId: 'test', scopes: [], sub: 'test-user' } }) // with auth context
 createMockContext({ uri: new URL('myscheme://item/123') })   // for resource handler testing
 ```
 
@@ -39,6 +41,8 @@ createMockContext({ uri: new URL('myscheme://item/123') })   // for resource han
 interface MockContextOptions {
   auth?: AuthContext;
   elicit?: (message: string, schema: z.ZodObject<z.ZodRawShape>) => Promise<ElicitResult>;
+  notifyResourceListChanged?: () => void;
+  notifyResourceUpdated?: (uri: string) => void;
   progress?: boolean;
   requestId?: string;
   sample?: (messages: SamplingMessage[], opts?: SamplingOpts) => Promise<CreateMessageResult>;
@@ -53,6 +57,8 @@ interface MockContextOptions {
 | _(none)_ | Minimal context — `ctx.state` operations throw without `tenantId`; `ctx.elicit`/`ctx.sample`/`ctx.progress` are `undefined` |
 | `auth` | Sets `ctx.auth` for scope-checking tests |
 | `elicit` | Assigns a function to `ctx.elicit` for testing elicitation calls |
+| `notifyResourceListChanged` | Assigns `ctx.notifyResourceListChanged` for resource notification tests |
+| `notifyResourceUpdated` | Assigns `ctx.notifyResourceUpdated` for resource update notification tests |
 | `progress` | Populates `ctx.progress` with real state-tracking implementation (see below) |
 | `requestId` | Overrides `ctx.requestId` (default: `'test-request-id'`) |
 | `sample` | Assigns a function to `ctx.sample` for testing sampling calls |
@@ -101,8 +107,8 @@ expect(log.calls.some(c => c.level === 'info' && c.msg.includes('Processing'))).
 ## Full test example
 
 ```ts
-// src/mcp-server/tools/definitions/my-tool.tool.test.ts
-import { describe, expect, it, vi } from 'vitest';
+// tests/tools/my-tool.tool.test.ts
+import { describe, expect, it } from 'vitest';
 import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
 import { myTool } from '@/mcp-server/tools/definitions/my-tool.tool.js';
 
@@ -120,15 +126,16 @@ describe('myTool', () => {
     await expect(myTool.handler(input, ctx)).rejects.toThrow();
   });
 
-  it('formats response correctly', () => {
+  it('formats response completely', () => {
     const result = { result: 'test' };
     const blocks = myTool.format!(result);
     expect(blocks[0].type).toBe('text');
+    expect((blocks[0] as { text?: string }).text).toContain('test');
   });
 });
 ```
 
-Parse input through `myTool.input.parse(...)` to validate against the Zod schema and produce the typed input the handler expects. Call `myTool.handler(input, ctx)` directly, not through the MCP SDK or any framework wrapper. Assert on the return value for happy paths; use `.rejects.toThrow()` for error paths. Test `format` separately if the tool defines one — it's a pure function and needs no `ctx`.
+Parse input through `myTool.input.parse(...)` to validate against the Zod schema and produce the typed input the handler expects. Call `myTool.handler(input, ctx)` directly, not through the MCP SDK or any framework wrapper. Assert on the return value for happy paths; use `.rejects.toThrow()` for error paths. Test `format` separately if the tool defines one — it's a pure function and needs no `ctx`. Verify the rendered text includes the fields the LLM needs, and for projection-style tools, add a case with non-default field selections.
 
 ---
 
@@ -138,7 +145,7 @@ Parse input through `myTool.input.parse(...)` to validate against the Zod schema
 it('uses elicitation when available', async () => {
   const elicit = vi.fn().mockResolvedValue({
     action: 'accept',
-    data: { format: 'json' },
+    content: { format: 'json' },
   });
   const ctx = createMockContext({ elicit });
   const input = myTool.input.parse({ query: 'hello' });
@@ -165,6 +172,80 @@ it('handles missing elicitation gracefully', async () => {
   await expect(myTool.handler(input, ctx)).resolves.toBeDefined();
 });
 ```
+
+---
+
+## Testing with form-based client payloads
+
+LLM clients only send populated fields. **Form-based clients** (MCP Inspector, web UIs) submit the full schema shape — optional object fields arrive with empty-string inner values instead of `undefined`. Both are valid MCP usage. Test that handlers handle both gracefully.
+
+```ts
+describe('form-client payloads', () => {
+  it('skips optional object when inner fields are empty strings', async () => {
+    const ctx = createMockContext();
+    // Form client sends the object with empty values instead of omitting it
+    const input = myTool.input.parse({
+      query: 'test',
+      dateRange: { minDate: '', maxDate: '' },
+    });
+    const result = await myTool.handler(input, ctx);
+    // Should succeed — empty dateRange is ignored, not passed downstream
+    expect(result.items).toBeDefined();
+  });
+
+  it('uses optional object when inner fields have real values', async () => {
+    const ctx = createMockContext();
+    const input = myTool.input.parse({
+      query: 'test',
+      dateRange: { minDate: '2025-01-01', maxDate: '2025-12-31' },
+    });
+    const result = await myTool.handler(input, ctx);
+    // Should apply the date filter
+    expect(result.items).toBeDefined();
+  });
+});
+```
+
+The pattern: parse through the schema (confirms Zod accepts the payload), call the handler, assert the empty-value case produces correct results — no errors, no corrupted downstream queries. Same applies to optional arrays: test with `[]` to verify the handler skips rather than passes through.
+
+---
+
+## Testing with sparse upstream payloads
+
+This is a different problem from form-client `''` payloads. Here the upstream API omits fields entirely. The risk is either a validation failure from an over-strict schema or a quiet lie where missing data turns into a concrete fact.
+
+```ts
+describe('sparse upstream payloads', () => {
+  it('preserves missing upstream fields as unknown', async () => {
+    const upstream = {
+      id: 'repo-123',
+      name: 'Widget Repo',
+      // archived and star_count omitted entirely
+    };
+
+    const normalized = normalizeRepo(upstream);
+    expect(normalized).toEqual({
+      id: 'repo-123',
+      name: 'Widget Repo',
+    });
+
+    const output = repoSearchTool.output.parse({
+      repos: [normalized],
+    });
+    const blocks = repoSearchTool.format!(output);
+    expect((blocks[0] as { text: string }).text).toContain('Archived:** Not available');
+    expect((blocks[0] as { text: string }).text).not.toContain('Archived:** No');
+  });
+});
+```
+
+**What to verify:**
+
+- Fixtures omit fields entirely, not just set them to `null` or `''`.
+- Normalization/helpers tolerate missing fields without fabricating defaults.
+- Handler output still validates against the declared output schema.
+- `format()` uses explicit unknown-state fallbacks instead of inventing facts.
+- Tool-semantic defaults are tested separately from upstream absence so the distinction stays clear.
 
 ---
 
@@ -209,8 +290,8 @@ describe('myTool with service', () => {
 });
 ```
 
-- Re-init services with `initMyService()` (or equivalent) per test suite — the module-level singleton must be reset so tests don't share state.
-- Vitest runs test files in separate worker threads — parallel file execution is safe by default.
+- Re-init services with `initMyService()` (or equivalent) in `beforeEach` when tests share a module-level singleton.
+- Vitest runs test files in separate workers — parallel file execution is safe by default.
 - Use `createMockContext({ tenantId })` whenever the handler accesses `ctx.state` — omitting `tenantId` causes `ctx.state` to throw.
 
 ---

--- a/skills/api-workers/SKILL.md
+++ b/skills/api-workers/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Cloudflare Workers deployment using `createWorkerHandler` from `@cyanheads/mcp-ts-core/worker`. Covers the full handler signature, binding types, CloudflareBindings extensibility, runtime compatibility guards, and wrangler.toml requirements.
 metadata:
   author: cyanheads
-  version: "1.0"
+  version: "1.1"
   audience: external
   type: reference
 ---
@@ -19,15 +19,15 @@ metadata:
 
 ```ts
 import { createWorkerHandler } from '@cyanheads/mcp-ts-core/worker';
-import { allToolDefinitions } from './mcp-server/tools/index.js';
-import { allResourceDefinitions } from './mcp-server/resources/index.js';
-import { allPromptDefinitions } from './mcp-server/prompts/index.js';
+import { echoTool } from './mcp-server/tools/definitions/echo.tool.js';
+import { echoResource } from './mcp-server/resources/definitions/echo.resource.js';
+import { echoPrompt } from './mcp-server/prompts/definitions/echo.prompt.js';
 import { initMyService } from './services/my-domain/my-service.js';
 
 export default createWorkerHandler({
-  tools: allToolDefinitions,
-  resources: allResourceDefinitions,
-  prompts: allPromptDefinitions,
+  tools: [echoTool],
+  resources: [echoResource],
+  prompts: [echoPrompt],
   setup(core) {
     initMyService(core.config, core.storage);
   },
@@ -39,6 +39,8 @@ export default createWorkerHandler({
 });
 ```
 
+Fresh scaffolds register definitions directly in the entry point as shown above. If your project later adds barrel files for definitions, importing arrays from those barrels is also fine.
+
 ### Options
 
 | Option | Type | Purpose |
@@ -46,6 +48,7 @@ export default createWorkerHandler({
 | `tools` | `AnyToolDefinition[]` | Tool definitions to register |
 | `resources` | `AnyResourceDefinition[]` | Resource definitions to register |
 | `prompts` | `PromptDefinition[]` | Prompt definitions to register |
+| `extensions` | `Record<string, object>` | SEP-2133 extensions to advertise in server capabilities |
 | `setup` | `(core: CoreServices) => void \| Promise<void>` | Runs after core services are ready, during the first request (lazy init inside the fetch handler) |
 | `extraEnvBindings` | `[bindingKey: string, processEnvKey: string][]` | Maps CF string bindings to `process.env` keys |
 | `extraObjectBindings` | `[bindingKey: string, globalKey: string][]` | Maps CF object bindings (KV, R2, D1, AI) to `globalThis` keys |

--- a/skills/design-mcp-server/SKILL.md
+++ b/skills/design-mcp-server/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Design the tool surface, resources, and service layer for a new MCP server. Use when starting a new server, planning a major feature expansion, or when the user describes a domain/API they want to expose via MCP. Produces a design doc at docs/design.md that drives implementation.
 metadata:
   author: cyanheads
-  version: "2.1"
+  version: "2.2"
   audience: external
   type: workflow
 ---
@@ -74,6 +74,7 @@ This is the raw material. Not everything becomes a tool.
 | Primitive | Use when | Examples |
 |:----------|:---------|:--------|
 | **Tool** | The default. Any operation or data access an agent needs to accomplish the server's purpose. | Search, create, update, analyze, fetch-by-ID, list reference data |
+| **App Tool** | Tool whose results benefit from interactive HTML UI (data visualization, forms, rich rendering). Uses `appTool()` + paired `appResource()`. Hosts without MCP Apps support receive the text fallback from `format()`. | Dashboards, data explorers, interactive charts, form-based workflows |
 | **Resource** | *Additionally* expose as a resource when the data is addressable by stable URI, read-only, and useful as injectable context. | Config, schemas, status, entity-by-ID lookups |
 | **Prompt** | Reusable message template that structures how the LLM approaches a task | Analysis framework, report template, review checklist |
 | **Neither** | Internal detail, admin-only, not useful to an LLM | Token refresh, webhook setup, migrations |
@@ -116,9 +117,7 @@ const gitBranch = tool('git_branch', {
 ```ts
 // Workflow tool — search + local filter pipeline, not a raw API proxy
 const findEligibleStudies = tool('clinicaltrials_find_eligible_studies', {
-  description: 'Matches patient demographics and medical profile to eligible clinical trials. '
-    + 'Filters by age, sex, conditions, location, and healthy volunteer status. '
-    + 'Returns ranked list of matching studies with eligibility explanations.',
+  description: 'Matches patient demographics and medical profile to eligible clinical trials. Filters by age, sex, conditions, location, and healthy volunteer status. Returns ranked list of matching studies with eligibility explanations.',
   // handler: listStudies() → filter by eligibility → rank by location proximity → slice
 });
 ```
@@ -141,21 +140,20 @@ The description is the LLM's primary signal for tool selection. It must answer: 
 
 - **Be concrete about capability.** "Search for clinical trial studies using queries and filters" beats "Interact with studies."
 - **Include operational guidance when it matters.** If the tool has prerequisites, constraints, or gotchas the LLM needs to know, say so in the description. Don't add boilerplate workflow hints when the tool is self-explanatory.
+- **Don't leak implementation details.** Descriptions are for the consumer, not the author. Internal endpoint paths, API call counts, internal parameter name mappings, and routing logic don't belong — describe what the tool does and when to use it, not how it's wired up.
 
 ```ts
 // Good — describes a prerequisite the LLM must know
-description: 'Set the session working directory for all git operations. '
-  + 'This allows subsequent git commands to omit the path parameter.'
+description: 'Set the session working directory for all git operations. This allows subsequent git commands to omit the path parameter.'
 
 // Good — self-explanatory, no workflow hints needed
 description: 'Show the working tree status including staged, unstaged, and untracked files.'
 
 // Good — warns about constraints
-description: 'Fetches trial results data for completed studies. '
-  + 'Only available for studies where hasResults is true.'
+description: 'Fetches trial results data for completed studies. Only available for studies where hasResults is true.'
 ```
 
-Context-dependent: a simple read-only tool needs a one-line description. A tool with prerequisites, modes, or non-obvious behavior needs more. Match depth of description to complexity of tool.
+Descriptions should be as long as needed — concise but complete. Don't artificially truncate, and don't pad with filler.
 
 #### Parameter descriptions
 
@@ -170,14 +168,11 @@ Every `.describe()` is prompt text the LLM reads. Parameters should convey: what
 ```ts
 // Good — explains cost, recommends action, names the alternative
 fields: z.array(z.string()).optional()
-  .describe('Specific fields to return (reduces payload size). '
-    + 'STRONGLY RECOMMENDED — without this, the full study record (~70KB each) is returned. '
-    + 'Use full data only when you need detailed eligibility criteria, locations, or results.'),
+  .describe('Specific fields to return (reduces payload size). Without this, the full study record (~70KB each) is returned. Use full data only when you need detailed eligibility criteria, locations, or results.'),
 
 // Good — explains what the flag does AND how to override
 autoExclude: z.boolean().default(true)
-  .describe('Automatically exclude lock files and generated files from diff output '
-    + 'to reduce context bloat. Set to false if you need to inspect these files.'),
+  .describe('Automatically exclude lock files and generated files from diff output to reduce context bloat. Set to false if you need to inspect these files.'),
 
 // Good — names the format and gives one example
 nctIds: z.union([z.string(), z.array(z.string()).max(5)])
@@ -200,8 +195,7 @@ The output schema and `format` function control what the LLM reads back. Design 
 output: z.object({
   diff: z.string().describe('Unified diff output.'),
   excludedFiles: z.array(z.string()).optional()
-    .describe('Files automatically excluded from the diff (e.g., lock files). '
-      + 'Call again with autoExclude=false to include them.'),
+    .describe('Files automatically excluded from the diff (e.g., lock files). Call again with autoExclude=false to include them.'),
 }),
 ```
 
@@ -243,9 +237,7 @@ When a tool wraps a complex query language or filter system, provide a simple sh
 ```ts
 // text_search handles the common case; query handles everything else
 text_search: z.string().optional()
-  .describe('Convenience shortcut: full-text search across title and abstract. '
-    + 'Equivalent to {"_or":[{"_text_any":{"title":"..."}},{"_text_any":{"abstract":"..."}}]}. '
-    + 'For more control, use the query parameter directly.'),
+  .describe('Convenience shortcut: full-text search across title and abstract. For structured filters or field-specific matching, use the query parameter instead.'),
 query: z.record(z.unknown()).optional()
   .describe('Full query object for structured filters. Supports operators: _eq, _gt, _and, _or, ...'),
 ```
@@ -419,10 +411,11 @@ If the user has already authorized implementation (e.g., "build me a ___ server"
 Execute the plan using the scaffolding skills:
 
 1. `add-service` for each service
-2. `add-tool` for each tool
-3. `add-resource` for each resource
-4. `add-prompt` for each prompt
-5. `devcheck` after each addition
+2. `add-tool` for each standard tool
+3. `add-app-tool` for each MCP Apps tool (creates paired tool + UI resource)
+4. `add-resource` for each standalone resource
+5. `add-prompt` for each prompt
+6. `devcheck` after each addition
 
 ## Checklist
 
@@ -438,6 +431,7 @@ Execute the plan using the scaffolding skills:
 - [ ] Error messages guide recovery — name what went wrong and what to do next
 - [ ] Annotations set correctly (`readOnlyHint`, `destructiveHint`, etc.)
 - [ ] Tool surface is self-sufficient — a tool-only agent can accomplish everything the server is for
+- [ ] MCP Apps tools identified where interactive UI adds value (and `format()` provides full text fallback for non-app hosts)
 - [ ] Resource URIs use `{param}` templates, pagination planned for large lists
 - [ ] Service layer planned (or explicitly skipped with reasoning)
 - [ ] Resilience planned for external API services (retry boundary, backoff, parse classification)

--- a/skills/devcheck/SKILL.md
+++ b/skills/devcheck/SKILL.md
@@ -4,37 +4,51 @@ description: >
   Lint, format, typecheck, and verify the project is clean. Use after making changes, before committing, or when the user asks to verify quality.
 metadata:
   author: cyanheads
-  version: "1.2"
+  version: "1.3"
   audience: external
   type: workflow
 ---
 
 ## What It Runs
 
-`bun run devcheck` runs lint and typecheck:
+`bun run devcheck` runs a broader check suite than just lint + types. By default it includes local hygiene checks, MCP definition linting, Biome, TypeScript, and slow dependency/security checks unless `--fast` is passed. Tests are opt-in via `--test`.
 
 | Check | Tool | Notes |
 |:------|:-----|:------|
+| TODOs / FIXMEs | `git grep` | Fails on tracked TODO/FIXME markers outside excluded files |
+| Tracked secrets | `git ls-files` | Flags tracked `.env`, keys, credentials, and similar sensitive files |
+| MCP definitions | `bun run scripts/lint-mcp.ts` | Validates tool/resource/prompt definitions against framework rules |
 | Biome | `biome check` | Unified lint + format — read-only by default |
 | TypeScript | `tsc --noEmit` | Full project type check |
+| Unused dependencies | `depcheck` | Runs by default; network-free but slower on large repos |
+| Security audit | `bun audit` | Runs by default unless `--fast` or `--no-audit` |
+| Outdated dependencies | `bun outdated` | Runs by default unless `--fast` or `--no-deps` |
+| Tests | `vitest run` | Off by default; enable with `bun run devcheck --test` |
 
-To auto-fix lint/format issues, run `bun run format` (which runs `biome check --fix .`).
+To auto-fix lint/format issues, run `bun run format`.
 
 ## Steps
 
 1. Run `bun run devcheck`
-2. Read the output — both checks run sequentially
-3. Fix any lint or type errors in source files
+2. Read the failing checks in the summary and per-check output
+3. Fix the reported issues
 4. Re-run `bun run devcheck` until clean
-5. Do not consider this skill complete until the command exits successfully with no errors
+5. If the change touches runtime behavior, also run `bun run devcheck --test` or `bun run test`
+6. Do not consider this skill complete until the required commands exit successfully with no errors
 
 ## Common Issues
 
 | Check | Error Type | Typical Fix |
 |:------|:-----------|:------------|
+| TODOs / FIXMEs | Tracked work markers | Resolve or remove the marker before committing |
+| Tracked secrets | Sensitive files in git | Add to `.gitignore` and remove from the index |
+| MCP definitions | Definition lint errors | Fix schema/name/annotation issues reported by `lint-mcp` |
 | Biome | Lint/format errors | Run `bun run format` to auto-fix, or address the flagged rule manually |
 | TypeScript | Type errors | Fix type mismatches, missing properties, incorrect generics |
+| Security audit | Vulnerabilities in direct deps | Update or replace the affected dependency |
+| Outdated deps | Stale package versions | Run `bun update` or allowlist intentionally pinned packages |
 
 ## Checklist
 
 - [ ] `bun run devcheck` exits with no errors
+- [ ] Tests run when needed (`bun run devcheck --test` or `bun run test`)

--- a/skills/field-test/SKILL.md
+++ b/skills/field-test/SKILL.md
@@ -4,14 +4,14 @@ description: >
   Exercise tools, resources, and prompts with real-world inputs to verify behavior end-to-end. Use after adding or modifying definitions, or when the user asks to test, try out, or verify their MCP surface. Calls each definition with realistic and adversarial inputs and produces a report of issues, pain points, and recommendations.
 metadata:
   author: cyanheads
-  version: "1.0"
+  version: "1.1"
   audience: external
   type: debug
 ---
 
 ## Context
 
-Unit tests (`add-test` skill) verify handler logic with mocked context. Field testing verifies the full picture: real server, real transport, real inputs, real outputs. It catches issues that unit tests miss — bad descriptions, awkward input shapes, unhelpful error messages, missing format functions, schema mismatches, and surprising edge-case behavior.
+Unit tests (`add-test` skill) verify handler logic with mocked context. Field testing verifies the full picture: real server, real transport, real inputs, real outputs. It catches issues that unit tests miss — bad descriptions, awkward input shapes, unhelpful error messages, missing format functions, schema mismatches, silent divergence between `structuredContent` and model-visible `content[]`, and surprising edge-case behavior.
 
 **Actively use** the tools — don't just read their code.
 
@@ -36,9 +36,17 @@ For every tool, resource, and prompt, run through these categories:
 | Category | What to test |
 |:---------|:-------------|
 | **Happy path** | Realistic input that should succeed. Verify output shape matches the output schema. Verify format function produces sensible content blocks. |
+| **`structuredContent` parity** | Compare the raw handler return, the data captured in `structuredContent`, and what `format()` renders into `content[]`. Flag fields or records that exist in the handler result or `structuredContent` but are absent from `content[]` unless the omission is explicit and acceptable for the tool's purpose. Most LLM clients only see `content[]`, so silent formatter drops are real bugs. |
 | **Variations** | Different valid input combinations — optional fields omitted, optional fields included, different enum values, min/max boundaries. |
+| **Field selection / projection** | For tools with `fields`, `include`, `expand`, `view`, or similar parameters, call the tool with non-default selections. Verify the handler returns the requested fields and `format()` renders each requested field rather than a hardcoded summary subset. |
 | **Edge cases** | Empty strings, zero values, very long inputs, special characters, Unicode. |
-| **Error paths** | Missing required fields, wrong types, nonexistent IDs, inputs that should trigger domain errors. Verify errors are clear and actionable. |
+| **Error paths** | Missing required fields, wrong types, nonexistent IDs, inputs that should trigger domain errors. Verify errors are clear and actionable — they should name what went wrong, why, and what to do next. |
+| **Empty results** | Inputs that match nothing. Verify the response explains *why* (echoes criteria, suggests broadening) rather than returning a bare empty array. |
+| **Partial success** | For tools that operate on multiple items, test cases where some succeed and some fail. Verify both outcomes are reported — not just the successes. |
+| **Annotations** | Review tool `annotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) against actual behavior. If a tool is marked read-only, verify it does not mutate state. If it is marked idempotent, verify retries with the same input are safe. If it is marked open-world false, verify it is not silently depending on live external systems. |
+| **Workflow chaining** | For servers with multi-step workflows, execute 1-2 representative chains end-to-end. Example: search → detail → follow-up action. Verify each step returns the IDs, cursors, URIs, tokens, or state needed for the next step without guessing. |
+| **Response quality** | Inspect successful responses for: (1) chaining IDs needed for follow-up calls, (2) operational metadata (counts, applied filters, truncation notices), (3) filtering transparency (if anything was excluded, does the response say what and how to include it?), (4) reasonable response size (not dumping unbounded data into context). See the `add-tool` skill's **Tool Response Design** section for the full set of patterns. |
+| **Resilience** | For tools backed by external APIs or slow subsystems, test or explicitly note rate-limit, timeout, and transient-failure behavior. Verify retries/backoff happen where intended, or at minimum that the error message clearly tells the user whether to retry, wait, or change input. |
 | **Descriptions** | Read every field's `.describe()` — would a user/LLM understand what to provide? Flag vague or missing descriptions. |
 
 #### Resources
@@ -88,18 +96,32 @@ Cross-cutting observations that aren't tied to a single definition:
 
 - Inconsistent error message patterns across tools
 - Missing format functions (raw JSON returned to user)
+- `structuredContent` contains data that `content[]` silently drops
+- Requested projected fields are returned programmatically but not rendered for the model
 - Description quality issues (vague, missing, or misleading)
 - Schema design issues (required fields that should be optional, missing defaults, overly broad types, non-JSON-Schema-serializable types like `z.custom()` or `z.date()`)
+- Annotation hints that do not match real behavior (`readOnlyHint`, `idempotentHint`, `openWorldHint`)
+- Response quality issues (empty results with no context, silent filtering, missing chaining IDs, oversized payloads, no operational metadata)
+- Multi-step workflows that cannot be completed because intermediate outputs omit required IDs, cursors, or URIs
+- Error messages that don't guide recovery (generic "not found" instead of naming alternatives)
+- Resilience issues (rate limits, timeouts, transient upstream failures handled poorly or explained poorly)
 - Performance observations (unexpectedly slow responses)
 
 ---
 
 ## Checklist
 
-- [ ] All registered tools tested (happy path + edge cases)
+- [ ] All registered tools tested (happy path + edge cases + empty results)
 - [ ] All registered resources tested (happy path + not found)
 - [ ] All registered prompts tested (happy path + defaults)
-- [ ] Error messages reviewed for clarity and actionability
+- [ ] Error messages reviewed for clarity and recovery guidance
+- [ ] Empty-result responses reviewed for context (criteria echo, suggestions)
+- [ ] `structuredContent` and `content[]` reviewed for parity
+- [ ] Field-selection / projection behavior reviewed where applicable
+- [ ] Response quality reviewed (chaining IDs, metadata, filtering transparency, payload size)
+- [ ] Tool annotations reviewed against actual behavior
+- [ ] Representative multi-step workflows exercised where applicable
+- [ ] External API resilience reviewed where applicable (rate limits, timeouts, transient failures)
 - [ ] Descriptions reviewed for completeness and accuracy
 - [ ] Format functions verified (or absence noted)
 - [ ] Summary report presented to user

--- a/skills/maintenance/SKILL.md
+++ b/skills/maintenance/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Sync skills and dependencies after package updates. Use after running `bun update @cyanheads/mcp-ts-core` to ensure project skills are up to date, or periodically to check for drift.
 metadata:
   author: cyanheads
-  version: "1.1"
+  version: "1.2"
   audience: external
   type: workflow
 ---
@@ -35,7 +35,8 @@ After `bun update @cyanheads/mcp-ts-core`, the package may have newer skills tha
 2. For any major version bumps, review changelogs before proceeding
 3. Run `bun update` to apply updates
 4. Run `bun audit` to check for vulnerabilities introduced by the update
-5. Run `bun run devcheck` to confirm lint, types, security, and tests still pass
+5. Run `bun run devcheck` to confirm lint, definitions, types, and dependency/security checks still pass
+6. Run `bun run test` to confirm runtime behavior still passes
 
 ## Checklist
 
@@ -44,3 +45,4 @@ After `bun update @cyanheads/mcp-ts-core`, the package may have newer skills tha
 - [ ] Dependencies updated (`bun update`)
 - [ ] `bun audit` passes (no new vulnerabilities)
 - [ ] `bun run devcheck` passes
+- [ ] `bun run test` passes

--- a/skills/migrate-mcp-ts-template/SKILL.md
+++ b/skills/migrate-mcp-ts-template/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Migrate an existing mcp-ts-template fork to use @cyanheads/mcp-ts-core as a package dependency. Use when a project was cloned/forked from github.com/cyanheads/mcp-ts-template and carries framework source code in its own src/ — this skill rewrites those internal imports to package subpath imports and removes the bundled framework files.
 metadata:
   author: cyanheads
-  version: "2.1"
+  version: "2.2"
   audience: external
   type: workflow
 ---
@@ -23,7 +23,7 @@ For the full exports catalog, see `CLAUDE.md` → Exports Reference.
 2. **Search for all `@/` imports** across `src/` that reference framework internals
 3. **Rewrite each import** using the mapping table below
 4. **Identify framework source files** now provided by the package (see candidates below) — review each for server-specific additions before cleaning up
-5. **Update entry point** (`src/index.ts`) to use `createApp()` from the package
+5. **Update entry point** (`src/index.ts`) to use `createApp()` from the package and the project's chosen registration pattern (fresh scaffold default: direct imports in `src/index.ts`)
 6. **Update build configs**:
    - `tsconfig.json` extends `@cyanheads/mcp-ts-core/tsconfig.base.json`
    - `biome.json` extends `@cyanheads/mcp-ts-core/biome`
@@ -113,19 +113,19 @@ Framework files within directories that contain server code:
 
 ## Entry point rewrite
 
-Replace the fork's `src/index.ts` with:
+Replace the fork's `src/index.ts` with the scaffold-default direct-registration pattern:
 
 ```ts
 #!/usr/bin/env node
 import { createApp } from '@cyanheads/mcp-ts-core';
-import { allToolDefinitions } from './mcp-server/tools/definitions/index.js';
-import { allResourceDefinitions } from './mcp-server/resources/definitions/index.js';
-import { allPromptDefinitions } from './mcp-server/prompts/definitions/index.js';
+import { echoTool } from './mcp-server/tools/definitions/echo.tool.js';
+import { echoResource } from './mcp-server/resources/definitions/echo.resource.js';
+import { echoPrompt } from './mcp-server/prompts/definitions/echo.prompt.js';
 
 await createApp({
-  tools: allToolDefinitions,
-  resources: allResourceDefinitions,
-  prompts: allPromptDefinitions,
+  tools: [echoTool],
+  resources: [echoResource],
+  prompts: [echoPrompt],
 });
 ```
 
@@ -133,14 +133,16 @@ Add `setup()` if the server initializes services:
 
 ```ts
 await createApp({
-  tools: allToolDefinitions,
-  resources: allResourceDefinitions,
-  prompts: allPromptDefinitions,
+  tools: [echoTool],
+  resources: [echoResource],
+  prompts: [echoPrompt],
   setup(core) {
     initMyService(core.config, core.storage);
   },
 });
 ```
+
+If the migrated project already has `definitions/index.ts` barrels and you want to keep them, that is fine. The important part is removing imports from framework internals and registering definitions consistently.
 
 ## Checklist
 

--- a/skills/polish-docs-meta/SKILL.md
+++ b/skills/polish-docs-meta/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Finalize documentation and project metadata for a ship-ready MCP server. Use after implementation is complete, tests pass, and devcheck is clean. Safe to run at any stage — each step checks current state and only acts on what still needs work.
 metadata:
   author: cyanheads
-  version: "1.2"
+  version: "1.3"
   audience: external
   type: workflow
 ---
@@ -23,7 +23,7 @@ Prefer running after implementation is complete, but safe to re-run at any point
 
 - [ ] All tools/resources/prompts implemented and registered
 - [ ] `bun run devcheck` passes
-- [ ] Tests pass (`npm test`)
+- [ ] Tests pass (`bun run test`)
 
 If these aren't met, address them first.
 
@@ -166,7 +166,7 @@ Run the full check suite one last time:
 
 ```bash
 bun run devcheck
-npm test
+bun run test
 ```
 
 Both must pass clean.
@@ -186,4 +186,4 @@ Both must pass clean.
 - [ ] `Dockerfile` OCI labels and runtime config accurate (if present)
 - [ ] `docs/tree.md` regenerated
 - [ ] `bun run devcheck` passes
-- [ ] `npm test` passes
+- [ ] `bun run test` passes

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -4,23 +4,23 @@ description: >
   Post-init orientation for an MCP server built on @cyanheads/mcp-ts-core. Use after running `@cyanheads/mcp-ts-core init` to understand the project structure, conventions, and skill sync model. Also use when onboarding to an existing project for the first time.
 metadata:
   author: cyanheads
-  version: "1.1"
+  version: "1.2"
   audience: external
   type: workflow
 ---
 
 ## Context
 
-This skill assumes `@cyanheads/mcp-ts-core init` has already run. The CLI created the project's `CLAUDE.md` and `AGENTS.md` (identical content), copied external skills to `skills/`, and scaffolded the directory structure with echo definitions as starting points. This skill covers what was created and what to do next.
+This skill assumes `@cyanheads/mcp-ts-core init` has already run. The CLI created the project's `CLAUDE.md` and `AGENTS.md` for different agents, copied external skills to `skills/`, and scaffolded the directory structure with echo definitions as starting points. This skill covers what was created and what to do next.
 
 ## Agent Protocol File
 
-The init CLI generates both `CLAUDE.md` and `AGENTS.md` with identical content. Keep the one your agent uses, discard the other:
+The init CLI generates both `CLAUDE.md` and `AGENTS.md` with the same purpose. Keep one authoritative file for the agent you actually use:
 
 - **Claude Code** — keep `CLAUDE.md`, discard `AGENTS.md`
 - **All other agents** (Codex, Cursor, Windsurf, etc.) — keep `AGENTS.md`, discard `CLAUDE.md`
 
-Both files serve the same purpose: project-specific agent instructions. Only one should exist in the committed project.
+Both files serve the same purpose: project-specific agent instructions. Prefer committing one authoritative copy rather than trying to keep both in sync by hand.
 
 For the full framework API, read:
 
@@ -34,7 +34,8 @@ What `init` actually creates:
 
 ```text
 CLAUDE.md                                       # Agent protocol (project-specific)
-AGENTS.md                                       # Same content — discard whichever you don't use
+AGENTS.md                                       # Alternate agent protocol file — keep the one your agent uses
+.github/ISSUE_TEMPLATE/                         # GitHub issue templates (bug report, feature request)
 skills/                                         # Project skills (source of truth)
 src/
   index.ts                                      # createApp() entry point
@@ -94,19 +95,19 @@ After the initial copy, use the `maintenance` skill to keep them in sync after p
 
 ## Project Scaffolding
 
-After installing dependencies (`npm install`, or `bun install` if using Bun), complete these one-time setup tasks:
+After installing dependencies (prefer `bun install`; `npm install` also works), complete these one-time setup tasks:
 
-1. **Update dependencies to latest** — `npx npm-check-updates -u && npm install` (or `bun update --latest` if using Bun). The scaffolded `package.json` pins minimum versions from when the framework was published; updating ensures you start with the latest compatible releases.
+1. **Update dependencies to latest** — `bun update --latest` (or `npx npm-check-updates -u && npm install` if using npm). The scaffolded `package.json` pins minimum versions from when the framework was published; updating ensures you start with the latest compatible releases.
 2. **Initialize git** — `git init && git add -A && git commit -m "chore: scaffold from @cyanheads/mcp-ts-core"`
 3. **Verify agent protocol placeholders** — if the `init` CLI was run without a `[name]` argument, `{{PACKAGE_NAME}}` may remain as a literal in `CLAUDE.md`/`AGENTS.md` and `package.json`. Replace it with the actual server name.
 
 ## Checklist
 
-- [ ] Agent protocol file selected — keep `CLAUDE.md` or `AGENTS.md`, discard the other
+- [ ] Agent protocol file selected — keep one authoritative file (`CLAUDE.md` or `AGENTS.md`)
 - [ ] `{{PACKAGE_NAME}}` placeholders replaced in agent protocol file (if not auto-substituted by init)
 - [ ] Core framework CLAUDE.md read (`node_modules/@cyanheads/mcp-ts-core/CLAUDE.md`)
 - [ ] Unused echo definitions cleaned up (and unregistered from `src/index.ts`)
 - [ ] Skills copied to agent directory (`cp -R skills/* .claude/skills/` or equivalent)
 - [ ] Project structure understood (definitions directories, entry point)
-- [ ] `npm run devcheck` passes
+- [ ] `bun run devcheck` passes
 - [ ] If new server: proceed to `design-mcp-server` skill to plan the tool surface

--- a/src/mcp-server/resources/definitions/bill.resource.ts
+++ b/src/mcp-server/resources/definitions/bill.resource.ts
@@ -19,11 +19,14 @@ export const billResource = resource('congress://bill/{congress}/{billType}/{bil
 
   async handler(params, ctx) {
     const api = getCongressApi();
-    const result = await api.getBill({
-      congress: Number(params.congress),
-      billType: params.billType as BillType,
-      billNumber: Number(params.billNumber),
-    });
+    const result = await api.getBill(
+      {
+        congress: Number(params.congress),
+        billType: params.billType as BillType,
+        billNumber: Number(params.billNumber),
+      },
+      ctx,
+    );
     ctx.log.info('Bill resource fetched', {
       congress: params.congress,
       billType: params.billType,

--- a/src/mcp-server/resources/definitions/committee.resource.ts
+++ b/src/mcp-server/resources/definitions/committee.resource.ts
@@ -21,7 +21,7 @@ export const committeeResource = resource('congress://committee/{committeeCode}'
       : params.committeeCode.startsWith('j')
         ? 'joint'
         : 'house';
-    const result = await api.getCommittee(chamber, params.committeeCode);
+    const result = await api.getCommittee(chamber, params.committeeCode, ctx);
     ctx.log.info('Committee resource fetched', { committeeCode: params.committeeCode });
     return result.committee;
   },

--- a/src/mcp-server/resources/definitions/current-congress.resource.ts
+++ b/src/mcp-server/resources/definitions/current-congress.resource.ts
@@ -20,7 +20,7 @@ export const currentCongressResource = resource('congress://current', {
 
   async handler(_params, ctx) {
     const api = getCongressApi();
-    const congress = await api.getCurrentCongress();
+    const congress = await api.getCurrentCongress(ctx);
     ctx.log.info('Current congress fetched', { congress: congress.congress });
     return congress;
   },

--- a/src/mcp-server/resources/definitions/member.resource.ts
+++ b/src/mcp-server/resources/definitions/member.resource.ts
@@ -16,7 +16,7 @@ export const memberResource = resource('congress://member/{bioguideId}', {
 
   async handler(params, ctx) {
     const api = getCongressApi();
-    const result = await api.getMember(params.bioguideId);
+    const result = await api.getMember(params.bioguideId, ctx);
     ctx.log.info('Member resource fetched', { bioguideId: params.bioguideId });
     return result.member;
   },

--- a/src/mcp-server/tools/definitions/bill-lookup.tool.ts
+++ b/src/mcp-server/tools/definitions/bill-lookup.tool.ts
@@ -6,8 +6,44 @@
 import { tool, z } from '@cyanheads/mcp-ts-core';
 
 import { formatBills } from '@/mcp-server/tools/format-helpers.js';
+import {
+  createPaginationSchema,
+  normalizeOptionalString,
+  StringOrNumberSchema,
+} from '@/mcp-server/tools/tool-helpers.js';
 import { getCongressApi } from '@/services/congress-api/congress-api-service.js';
 import type { BillSubResource } from '@/services/congress-api/types.js';
+
+const PaginationSchema = createPaginationSchema('Total number of matching records.');
+
+const BillDetailSchema = z
+  .object({
+    congress: StringOrNumberSchema.optional().describe(
+      'Congress number when Congress.gov includes it.',
+    ),
+    type: z.string().optional().describe('Bill type code when provided by Congress.gov.'),
+    number: StringOrNumberSchema.optional().describe('Bill number when provided by Congress.gov.'),
+    title: z
+      .string()
+      .optional()
+      .describe('Bill title when provided by Congress.gov. Omitted when unknown.'),
+    updateDate: z
+      .string()
+      .optional()
+      .describe('Last update timestamp when provided by Congress.gov.'),
+    latestAction: z
+      .object({
+        actionDate: z
+          .string()
+          .optional()
+          .describe('Latest action date when provided by Congress.gov.'),
+        text: z.string().optional().describe('Latest action text when provided by Congress.gov.'),
+      })
+      .passthrough()
+      .optional()
+      .describe('Latest action summary when provided by Congress.gov.'),
+  })
+  .passthrough();
 
 const BillTypeEnum = z.enum(['hr', 's', 'hjres', 'sjres', 'hconres', 'sconres', 'hres', 'sres']);
 
@@ -30,16 +66,7 @@ const SUB_RESOURCE_MAP: Record<string, string> = {
 };
 
 export const billLookupTool = tool('congressgov_bill_lookup', {
-  description: `Browse and retrieve U.S. legislative bill data from Congress.gov.
-
-IMPORTANT: This API has no keyword search. To find bills, filter by congress number, bill type, and/or date range. Use 'congressgov_bill_summaries' to discover recently summarized legislation, or 'congressgov_member_lookup' to find bills via their sponsor.
-
-Operations:
-- list: Browse bills. Requires 'congress'. Add 'billType' to narrow by chamber/type.
-- get: Full bill detail including sponsor, policy area, CBO estimates, and law info.
-- actions/amendments/cosponsors/committees/subjects/summaries/text/titles/related: Sub-resources for a specific bill. Require congress + billType + billNumber.
-
-For enacted laws, use 'congressgov_enacted_laws' instead.`,
+  description: `Browse and retrieve U.S. legislative bill data from Congress.gov. The API has no keyword search — discover bills by filtering on congress, bill type, and date range, or cross-reference via 'congressgov_bill_summaries' (recent CRS summaries) and 'congressgov_member_lookup' (bills by sponsor). Use 'list' to browse (requires congress), 'get' for full bill detail (sponsor, policy area, CBO estimates, law info), or drill into a specific bill with 'actions', 'amendments', 'cosponsors', 'committees', 'subjects', 'summaries', 'text', 'titles', or 'related' (each requires congress + billType + billNumber). For enacted laws, use 'congressgov_enacted_laws'.`,
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
   input: z.object({
     operation: OperationEnum.describe('Which data to retrieve.'),
@@ -61,21 +88,47 @@ For enacted laws, use 'congressgov_enacted_laws' instead.`,
     limit: z.number().int().min(1).max(250).default(20).describe('Results per page (1-250).'),
     offset: z.number().int().min(0).default(0).describe('Pagination offset.'),
   }),
-  output: z.object({}).passthrough().describe('Bill data from Congress.gov API.'),
+  output: z
+    .object({
+      data: z
+        .array(z.unknown())
+        .optional()
+        .describe(
+          'List or sub-resource records for list and drill-down operations. Preserves upstream item shapes instead of narrowing them.',
+        ),
+      pagination: PaginationSchema.optional().describe(
+        'Pagination metadata for list and sub-resource operations.',
+      ),
+      bill: BillDetailSchema.optional().describe('Bill detail for operation="get".'),
+      rawResponse: z
+        .unknown()
+        .optional()
+        .describe('Full upstream Congress.gov response envelope before normalization.'),
+    })
+    .passthrough()
+    .refine((result) => (Array.isArray(result.data) && !!result.pagination) || !!result.bill, {
+      message: 'Expected either paginated list data or a bill detail object.',
+    })
+    .describe('Bill data from Congress.gov API.'),
   format: formatBills,
 
   async handler(input, ctx) {
     const api = getCongressApi();
+    const fromDateTime = normalizeOptionalString(input.fromDateTime);
+    const toDateTime = normalizeOptionalString(input.toDateTime);
 
     if (input.operation === 'list') {
-      const result = await api.listBills({
-        congress: input.congress,
-        billType: input.billType,
-        fromDateTime: input.fromDateTime,
-        toDateTime: input.toDateTime,
-        limit: input.limit,
-        offset: input.offset,
-      });
+      const result = await api.listBills(
+        {
+          congress: input.congress,
+          billType: input.billType,
+          fromDateTime,
+          toDateTime,
+          limit: input.limit,
+          offset: input.offset,
+        },
+        ctx,
+      );
       ctx.log.info('Bills listed', { congress: input.congress, count: result.data.length });
       return result;
     }
@@ -87,11 +140,14 @@ For enacted laws, use 'congressgov_enacted_laws' instead.`,
     }
 
     if (input.operation === 'get') {
-      const result = await api.getBill({
-        congress: input.congress,
-        billType: input.billType,
-        billNumber: input.billNumber,
-      });
+      const result = await api.getBill(
+        {
+          congress: input.congress,
+          billType: input.billType,
+          billNumber: input.billNumber,
+        },
+        ctx,
+      );
       ctx.log.info('Bill retrieved', {
         congress: input.congress,
         billType: input.billType,
@@ -101,14 +157,17 @@ For enacted laws, use 'congressgov_enacted_laws' instead.`,
     }
 
     const subResource = SUB_RESOURCE_MAP[input.operation] ?? input.operation;
-    const result = await api.getBillSubResource({
-      congress: input.congress,
-      billType: input.billType,
-      billNumber: input.billNumber,
-      subResource: subResource as BillSubResource,
-      limit: input.limit,
-      offset: input.offset,
-    });
+    const result = await api.getBillSubResource(
+      {
+        congress: input.congress,
+        billType: input.billType,
+        billNumber: input.billNumber,
+        subResource: subResource as BillSubResource,
+        limit: input.limit,
+        offset: input.offset,
+      },
+      ctx,
+    );
     ctx.log.info('Bill sub-resource retrieved', {
       congress: input.congress,
       billType: input.billType,

--- a/src/mcp-server/tools/definitions/bill-lookup.tool.ts
+++ b/src/mcp-server/tools/definitions/bill-lookup.tool.ts
@@ -100,10 +100,6 @@ export const billLookupTool = tool('congressgov_bill_lookup', {
         'Pagination metadata for list and sub-resource operations.',
       ),
       bill: BillDetailSchema.optional().describe('Bill detail for operation="get".'),
-      rawResponse: z
-        .unknown()
-        .optional()
-        .describe('Full upstream Congress.gov response envelope before normalization.'),
     })
     .passthrough()
     .refine((result) => (Array.isArray(result.data) && !!result.pagination) || !!result.bill, {

--- a/src/mcp-server/tools/definitions/bill-summaries.tool.ts
+++ b/src/mcp-server/tools/definitions/bill-summaries.tool.ts
@@ -48,10 +48,6 @@ export const billSummariesTool = tool('congressgov_bill_summaries', {
           'Bill summaries returned by Congress.gov. Preserves upstream item shapes instead of narrowing them.',
         ),
       pagination: PaginationSchema.describe('Pagination metadata for the returned summaries.'),
-      rawResponse: z
-        .unknown()
-        .optional()
-        .describe('Full upstream Congress.gov response envelope before normalization.'),
     })
     .passthrough()
     .describe('Bill summary data from Congress.gov API.'),

--- a/src/mcp-server/tools/definitions/bill-summaries.tool.ts
+++ b/src/mcp-server/tools/definitions/bill-summaries.tool.ts
@@ -6,14 +6,18 @@
 import { tool, z } from '@cyanheads/mcp-ts-core';
 
 import { formatSummaries } from '@/mcp-server/tools/format-helpers.js';
+import {
+  createPaginationSchema,
+  normalizeOptionalString,
+} from '@/mcp-server/tools/tool-helpers.js';
 import { getCongressApi } from '@/services/congress-api/congress-api-service.js';
 
+const DEFAULT_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
+
+const PaginationSchema = createPaginationSchema('Total number of matching summaries.');
+
 export const billSummariesTool = tool('congressgov_bill_summaries', {
-  description: `Browse recent CRS (Congressional Research Service) bill summaries.
-
-This is the best tool for answering "what's happening in Congress?" — CRS analysts write plain-language summaries of bills at each legislative stage.
-
-By default, returns summaries from the last 7 days. Specify fromDateTime/toDateTime for custom ranges. Each summary includes the associated bill reference (congress, type, number) for follow-up with congressgov_bill_lookup.`,
+  description: `Browse recent CRS (Congressional Research Service) bill summaries — plain-language summaries of bills at each legislative stage, and the best tool for answering "what's happening in Congress?". Defaults to the last 7 days; specify fromDateTime/toDateTime for custom ranges. Each summary includes the associated bill reference (congress, type, number) for follow-up with 'congressgov_bill_lookup'.`,
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
   input: z.object({
     congress: z
@@ -36,10 +40,27 @@ By default, returns summaries from the last 7 days. Specify fromDateTime/toDateT
     limit: z.number().int().min(1).max(250).default(20).describe('Results per page (1-250).'),
     offset: z.number().int().min(0).default(0).describe('Pagination offset.'),
   }),
-  output: z.object({}).passthrough().describe('Bill summary data from Congress.gov API.'),
+  output: z
+    .object({
+      data: z
+        .array(z.unknown())
+        .describe(
+          'Bill summaries returned by Congress.gov. Preserves upstream item shapes instead of narrowing them.',
+        ),
+      pagination: PaginationSchema.describe('Pagination metadata for the returned summaries.'),
+      rawResponse: z
+        .unknown()
+        .optional()
+        .describe('Full upstream Congress.gov response envelope before normalization.'),
+    })
+    .passthrough()
+    .describe('Bill summary data from Congress.gov API.'),
   format: formatSummaries,
 
   async handler(input, ctx) {
+    const fromDateTimeInput = normalizeOptionalString(input.fromDateTime);
+    const toDateTimeInput = normalizeOptionalString(input.toDateTime);
+
     if (input.billType && !input.congress) {
       throw new Error(
         "The 'billType' filter requires 'congress'. Provide both or omit billType to browse across all types.",
@@ -47,20 +68,23 @@ By default, returns summaries from the last 7 days. Specify fromDateTime/toDateT
     }
 
     const fromDateTime =
-      input.fromDateTime ??
-      (!input.toDateTime
-        ? new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z')
+      fromDateTimeInput ??
+      (!toDateTimeInput
+        ? new Date(Date.now() - DEFAULT_LOOKBACK_MS).toISOString().replace(/\.\d{3}Z$/, 'Z')
         : undefined);
 
     const api = getCongressApi();
-    const result = await api.listSummaries({
-      congress: input.congress,
-      billType: input.billType,
-      fromDateTime,
-      toDateTime: input.toDateTime,
-      limit: input.limit,
-      offset: input.offset,
-    });
+    const result = await api.listSummaries(
+      {
+        congress: input.congress,
+        billType: input.billType,
+        fromDateTime,
+        toDateTime: toDateTimeInput,
+        limit: input.limit,
+        offset: input.offset,
+      },
+      ctx,
+    );
     ctx.log.info('Summaries listed', { count: result.data.length });
     return result;
   },

--- a/src/mcp-server/tools/definitions/committee-lookup.tool.ts
+++ b/src/mcp-server/tools/definitions/committee-lookup.tool.ts
@@ -9,11 +9,7 @@ import { formatCommittees } from '@/mcp-server/tools/format-helpers.js';
 import { getCongressApi } from '@/services/congress-api/congress-api-service.js';
 
 export const committeeLookupTool = tool('congressgov_committee_lookup', {
-  description: `Browse congressional committees and their legislation, reports, and nominations.
-
-Committee codes follow the pattern: chamber prefix (h/s/j) + abbreviation + number. Use 'list' to discover codes, then drill into bills, reports, or nominations.
-
-The 'nominations' operation is available for Senate committees only. The committeeCode also works with the congress://committee/{committeeCode} resource.`,
+  description: `Browse congressional committees and their legislation, reports, and nominations. Committee codes follow the pattern chamber-prefix (h/s/j) + abbreviation + number — use 'list' to discover codes, then 'get' or drill into 'bills', 'reports', or 'nominations' ('nominations' is Senate-only). The committeeCode also works with the congress://committee/{committeeCode} resource.`,
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
   input: z.object({
     operation: z
@@ -38,12 +34,15 @@ The 'nominations' operation is available for Senate committees only. The committ
     const api = getCongressApi();
 
     if (input.operation === 'list') {
-      const result = await api.listCommittees({
-        congress: input.congress,
-        chamber: input.chamber,
-        limit: input.limit,
-        offset: input.offset,
-      });
+      const result = await api.listCommittees(
+        {
+          congress: input.congress,
+          chamber: input.chamber,
+          limit: input.limit,
+          offset: input.offset,
+        },
+        ctx,
+      );
       ctx.log.info('Committees listed', { count: result.data.length });
       return result;
     }
@@ -55,7 +54,7 @@ The 'nominations' operation is available for Senate committees only. The committ
     }
 
     if (input.operation === 'get') {
-      const result = await api.getCommittee(input.chamber, input.committeeCode);
+      const result = await api.getCommittee(input.chamber, input.committeeCode, ctx);
       ctx.log.info('Committee retrieved', { committeeCode: input.committeeCode });
       return result;
     }
@@ -66,13 +65,16 @@ The 'nominations' operation is available for Senate committees only. The committ
       );
     }
 
-    const result = await api.getCommitteeSubResource({
-      chamber: input.chamber,
-      committeeCode: input.committeeCode,
-      subResource: input.operation,
-      limit: input.limit,
-      offset: input.offset,
-    });
+    const result = await api.getCommitteeSubResource(
+      {
+        chamber: input.chamber,
+        committeeCode: input.committeeCode,
+        subResource: input.operation,
+        limit: input.limit,
+        offset: input.offset,
+      },
+      ctx,
+    );
     ctx.log.info('Committee sub-resource retrieved', {
       committeeCode: input.committeeCode,
       subResource: input.operation,

--- a/src/mcp-server/tools/definitions/committee-reports.tool.ts
+++ b/src/mcp-server/tools/definitions/committee-reports.tool.ts
@@ -9,14 +9,7 @@ import { formatCommitteeReports } from '@/mcp-server/tools/format-helpers.js';
 import { getCongressApi } from '@/services/congress-api/congress-api-service.js';
 
 export const committeeReportsTool = tool('congressgov_committee_reports', {
-  description: `Browse and retrieve committee reports from Congress.gov.
-
-Committee reports accompany legislation reported out of committee. They explain the bill's purpose, committee amendments, dissenting views, and the committee vote.
-
-Report types:
-- hrpt: House reports
-- srpt: Senate reports
-- erpt: Executive reports`,
+  description: `Browse and retrieve committee reports from Congress.gov — reports accompany legislation reported out of committee and explain the bill's purpose, committee amendments, dissenting views, and the committee vote. Report types are 'hrpt' (House), 'srpt' (Senate), and 'erpt' (Executive).`,
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
   input: z.object({
     operation: z.enum(['list', 'get', 'text']).describe('Which data to retrieve.'),
@@ -41,12 +34,15 @@ Report types:
     const api = getCongressApi();
 
     if (input.operation === 'list') {
-      const result = await api.listCommitteeReports({
-        congress: input.congress,
-        reportType: input.reportType,
-        limit: input.limit,
-        offset: input.offset,
-      });
+      const result = await api.listCommitteeReports(
+        {
+          congress: input.congress,
+          reportType: input.reportType,
+          limit: input.limit,
+          offset: input.offset,
+        },
+        ctx,
+      );
       ctx.log.info('Committee reports listed', {
         congress: input.congress,
         count: result.data.length,
@@ -61,11 +57,14 @@ Report types:
     }
 
     if (input.operation === 'text') {
-      const result = await api.getCommitteeReportText({
-        congress: input.congress,
-        reportType: input.reportType,
-        reportNumber: input.reportNumber,
-      });
+      const result = await api.getCommitteeReportText(
+        {
+          congress: input.congress,
+          reportType: input.reportType,
+          reportNumber: input.reportNumber,
+        },
+        ctx,
+      );
       ctx.log.info('Committee report text retrieved', {
         congress: input.congress,
         reportType: input.reportType,
@@ -74,11 +73,14 @@ Report types:
       return result;
     }
 
-    const result = await api.getCommitteeReport({
-      congress: input.congress,
-      reportType: input.reportType,
-      reportNumber: input.reportNumber,
-    });
+    const result = await api.getCommitteeReport(
+      {
+        congress: input.congress,
+        reportType: input.reportType,
+        reportNumber: input.reportNumber,
+      },
+      ctx,
+    );
     ctx.log.info('Committee report retrieved', {
       congress: input.congress,
       reportType: input.reportType,

--- a/src/mcp-server/tools/definitions/crs-reports.tool.ts
+++ b/src/mcp-server/tools/definitions/crs-reports.tool.ts
@@ -54,10 +54,6 @@ export const crsReportsTool = tool('congressgov_crs_reports', {
         ),
       pagination: PaginationSchema.optional().describe('Pagination metadata for list results.'),
       report: CrsReportSchema.optional().describe('CRS report detail when operation="get".'),
-      rawResponse: z
-        .unknown()
-        .optional()
-        .describe('Full upstream Congress.gov response envelope before normalization.'),
     })
     .passthrough()
     .refine((result) => (Array.isArray(result.data) && !!result.pagination) || !!result.report, {

--- a/src/mcp-server/tools/definitions/crs-reports.tool.ts
+++ b/src/mcp-server/tools/definitions/crs-reports.tool.ts
@@ -6,14 +6,34 @@
 import { tool, z } from '@cyanheads/mcp-ts-core';
 
 import { formatCrsReports } from '@/mcp-server/tools/format-helpers.js';
+import { createPaginationSchema } from '@/mcp-server/tools/tool-helpers.js';
 import { getCongressApi } from '@/services/congress-api/congress-api-service.js';
 
+const PaginationSchema = createPaginationSchema('Total number of matching CRS reports.');
+
+const CrsReportSchema = z
+  .object({
+    reportNumber: z
+      .string()
+      .optional()
+      .describe('CRS report identifier when provided by Congress.gov.'),
+    title: z
+      .string()
+      .optional()
+      .describe('CRS report title when provided by Congress.gov. Omitted when unknown.'),
+    summary: z
+      .string()
+      .optional()
+      .describe('CRS report summary when provided by Congress.gov. Omitted when unknown.'),
+    updateDate: z
+      .string()
+      .optional()
+      .describe('Last update timestamp when provided by Congress.gov.'),
+  })
+  .passthrough();
+
 export const crsReportsTool = tool('congressgov_crs_reports', {
-  description: `Browse and retrieve CRS (Congressional Research Service) reports — nonpartisan policy analyses written by subject-matter experts at the Library of Congress.
-
-CRS reports cover policy areas, legislative proposals, and legal questions. Report IDs use letter-number codes (e.g., R40097, RL33612, IF12345).
-
-Use 'list' to browse available reports, 'get' for full detail including authors, topics, summary, and available download formats.`,
+  description: `Browse and retrieve CRS (Congressional Research Service) reports — nonpartisan policy analyses by subject-matter experts at the Library of Congress, covering policy areas, legislative proposals, and legal questions. Report IDs use letter-number codes (e.g., R40097, RL33612, IF12345). Use 'list' to browse available reports or 'get' for full detail (authors, topics, summary, download formats).`,
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
   input: z.object({
     operation: z.enum(['list', 'get']).describe('Which data to retrieve.'),
@@ -24,14 +44,33 @@ Use 'list' to browse available reports, 'get' for full detail including authors,
     limit: z.number().int().min(1).max(250).default(20).describe('Results per page (1-250).'),
     offset: z.number().int().min(0).default(0).describe('Pagination offset.'),
   }),
-  output: z.object({}).passthrough().describe('CRS report data from Congress.gov API.'),
+  output: z
+    .object({
+      data: z
+        .array(z.unknown())
+        .optional()
+        .describe(
+          'CRS report list results when operation="list". Preserves upstream item shapes instead of narrowing them.',
+        ),
+      pagination: PaginationSchema.optional().describe('Pagination metadata for list results.'),
+      report: CrsReportSchema.optional().describe('CRS report detail when operation="get".'),
+      rawResponse: z
+        .unknown()
+        .optional()
+        .describe('Full upstream Congress.gov response envelope before normalization.'),
+    })
+    .passthrough()
+    .refine((result) => (Array.isArray(result.data) && !!result.pagination) || !!result.report, {
+      message: 'Expected either paginated list data or a CRS report detail object.',
+    })
+    .describe('CRS report data from Congress.gov API.'),
   format: formatCrsReports,
 
   async handler(input, ctx) {
     const api = getCongressApi();
 
     if (input.operation === 'list') {
-      const result = await api.listCrsReports({ limit: input.limit, offset: input.offset });
+      const result = await api.listCrsReports({ limit: input.limit, offset: input.offset }, ctx);
       ctx.log.info('CRS reports listed', { count: result.data.length });
       return result;
     }
@@ -42,7 +81,7 @@ Use 'list' to browse available reports, 'get' for full detail including authors,
       );
     }
 
-    const result = await api.getCrsReport({ reportNumber: input.reportNumber });
+    const result = await api.getCrsReport({ reportNumber: input.reportNumber }, ctx);
     ctx.log.info('CRS report retrieved', { reportNumber: input.reportNumber });
     return result;
   },

--- a/src/mcp-server/tools/definitions/daily-record.tool.ts
+++ b/src/mcp-server/tools/definitions/daily-record.tool.ts
@@ -9,9 +9,7 @@ import { formatDailyRecord } from '@/mcp-server/tools/format-helpers.js';
 import { getCongressApi } from '@/services/congress-api/congress-api-service.js';
 
 export const dailyRecordTool = tool('congressgov_daily_record', {
-  description: `Browse the daily Congressional Record — floor speeches, debates, and legislative text published each day Congress is in session.
-
-Navigation is hierarchical: list → volumes, issues → individual articles. Use 'list' to find recent volumes, 'issues' to see what's in a volume, and 'articles' to access individual speeches and debate sections.`,
+  description: `Browse the daily Congressional Record — floor speeches, debates, and legislative text published each day Congress is in session. Navigation is hierarchical: list → volumes, issues → individual articles. Use 'list' to find recent volumes, 'issues' to see what's in a volume, and 'articles' to access individual speeches and debate sections.`,
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
   input: z.object({
     operation: z.enum(['list', 'issues', 'articles']).describe('Which data to retrieve.'),
@@ -37,7 +35,7 @@ Navigation is hierarchical: list → volumes, issues → individual articles. Us
     const api = getCongressApi();
 
     if (input.operation === 'list') {
-      const result = await api.listDailyRecord({ limit: input.limit, offset: input.offset });
+      const result = await api.listDailyRecord({ limit: input.limit, offset: input.offset }, ctx);
       ctx.log.info('Daily record listed');
       return result;
     }
@@ -49,11 +47,14 @@ Navigation is hierarchical: list → volumes, issues → individual articles. Us
     }
 
     if (input.operation === 'issues') {
-      const result = await api.getDailyIssues({
-        volumeNumber: input.volumeNumber,
-        limit: input.limit,
-        offset: input.offset,
-      });
+      const result = await api.getDailyIssues(
+        {
+          volumeNumber: input.volumeNumber,
+          limit: input.limit,
+          offset: input.offset,
+        },
+        ctx,
+      );
       ctx.log.info('Daily record issues retrieved', { volumeNumber: input.volumeNumber });
       return result;
     }
@@ -64,12 +65,15 @@ Navigation is hierarchical: list → volumes, issues → individual articles. Us
       );
     }
 
-    const result = await api.getDailyArticles({
-      volumeNumber: input.volumeNumber,
-      issueNumber: input.issueNumber,
-      limit: input.limit,
-      offset: input.offset,
-    });
+    const result = await api.getDailyArticles(
+      {
+        volumeNumber: input.volumeNumber,
+        issueNumber: input.issueNumber,
+        limit: input.limit,
+        offset: input.offset,
+      },
+      ctx,
+    );
     ctx.log.info('Daily record articles retrieved', {
       volumeNumber: input.volumeNumber,
       issueNumber: input.issueNumber,

--- a/src/mcp-server/tools/definitions/enacted-laws.tool.ts
+++ b/src/mcp-server/tools/definitions/enacted-laws.tool.ts
@@ -9,13 +9,7 @@ import { formatLaws } from '@/mcp-server/tools/format-helpers.js';
 import { getCongressApi } from '@/services/congress-api/congress-api-service.js';
 
 export const enactedLawsTool = tool('congressgov_enacted_laws', {
-  description: `Browse enacted public and private laws from Congress.gov.
-
-Use 'list' to browse laws by congress. Each law references its origin bill — use 'congressgov_bill_lookup' with that reference for the full legislative history.
-
-Law types:
-- pub: Public laws (general application, most common)
-- priv: Private laws (specific individuals or entities)`,
+  description: `Browse enacted public and private laws from Congress.gov. Use 'list' to browse laws by congress. Each law references its origin bill — use 'congressgov_bill_lookup' with that reference for the full legislative history. Law types: pub: Public laws (general application, most common); priv: Private laws (specific individuals or entities)`,
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
   input: z.object({
     operation: z.enum(['list', 'get']).describe('Which data to retrieve.'),
@@ -32,12 +26,15 @@ Law types:
     const api = getCongressApi();
 
     if (input.operation === 'list') {
-      const result = await api.listLaws({
-        congress: input.congress,
-        lawType: input.lawType,
-        limit: input.limit,
-        offset: input.offset,
-      });
+      const result = await api.listLaws(
+        {
+          congress: input.congress,
+          lawType: input.lawType,
+          limit: input.limit,
+          offset: input.offset,
+        },
+        ctx,
+      );
       ctx.log.info('Laws listed', { congress: input.congress, count: result.data.length });
       return result;
     }
@@ -46,11 +43,14 @@ Law types:
       throw new Error("The 'get' operation requires lawType ('pub' or 'priv') and lawNumber.");
     }
 
-    const result = await api.getLaw({
-      congress: input.congress,
-      lawType: input.lawType,
-      lawNumber: input.lawNumber,
-    });
+    const result = await api.getLaw(
+      {
+        congress: input.congress,
+        lawType: input.lawType,
+        lawNumber: input.lawNumber,
+      },
+      ctx,
+    );
     ctx.log.info('Law retrieved', {
       congress: input.congress,
       lawType: input.lawType,

--- a/src/mcp-server/tools/definitions/member-lookup.tool.ts
+++ b/src/mcp-server/tools/definitions/member-lookup.tool.ts
@@ -57,10 +57,6 @@ export const memberLookupTool = tool('congressgov_member_lookup', {
       member: UnknownRecordSchema.optional().describe(
         'Member profile detail when operation="get".',
       ),
-      rawResponse: z
-        .unknown()
-        .optional()
-        .describe('Full upstream Congress.gov response envelope before normalization.'),
     })
     .passthrough()
     .refine((result) => (Array.isArray(result.data) && !!result.pagination) || !!result.member, {

--- a/src/mcp-server/tools/definitions/member-lookup.tool.ts
+++ b/src/mcp-server/tools/definitions/member-lookup.tool.ts
@@ -6,17 +6,13 @@
 import { tool, z } from '@cyanheads/mcp-ts-core';
 
 import { formatMembers } from '@/mcp-server/tools/format-helpers.js';
+import { createPaginationSchema, UnknownRecordSchema } from '@/mcp-server/tools/tool-helpers.js';
 import { getCongressApi } from '@/services/congress-api/congress-api-service.js';
 
+const PaginationSchema = createPaginationSchema('Total number of matching members or bills.');
+
 export const memberLookupTool = tool('congressgov_member_lookup', {
-  description: `Discover congressional members and their legislative activity.
-
-The API does not support name search. To find a member:
-- By location: use 'list' with stateCode (and optionally district)
-- By congress: use 'list' with congress number
-- By current status: use 'list' with currentMember=true
-
-Once you have a bioguideId, use 'get' for full profile or 'sponsored'/'cosponsored' for legislative portfolio. The bioguideId also works with the congress://member/{bioguideId} resource.`,
+  description: `Discover congressional members and their legislative activity. The API has no name search — use 'list' with stateCode (optionally with district), with a congress number, or with currentMember=true to find members. Once you have a bioguideId, use 'get' for full profile or 'sponsored'/'cosponsored' for their legislative portfolio. The bioguideId also works with the congress://member/{bioguideId} resource.`,
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
   input: z.object({
     operation: z
@@ -43,11 +39,34 @@ Once you have a bioguideId, use 'get' for full profile or 'sponsored'/'cosponsor
     currentMember: z
       .boolean()
       .optional()
-      .describe('Filter to currently serving members. Defaults to false.'),
+      .describe(
+        'Filter to currently serving members. Omit to include both current and former members.',
+      ),
     limit: z.number().int().min(1).max(250).default(20).describe('Results per page (1-250).'),
     offset: z.number().int().min(0).default(0).describe('Pagination offset.'),
   }),
-  output: z.object({}).passthrough().describe('Member data from Congress.gov API.'),
+  output: z
+    .object({
+      data: z
+        .array(z.unknown())
+        .optional()
+        .describe('Paginated member or legislation results. Preserves upstream item shapes.'),
+      pagination: PaginationSchema.optional().describe(
+        'Pagination metadata for list, sponsored, and cosponsored operations.',
+      ),
+      member: UnknownRecordSchema.optional().describe(
+        'Member profile detail when operation="get".',
+      ),
+      rawResponse: z
+        .unknown()
+        .optional()
+        .describe('Full upstream Congress.gov response envelope before normalization.'),
+    })
+    .passthrough()
+    .refine((result) => (Array.isArray(result.data) && !!result.pagination) || !!result.member, {
+      message: 'Expected either paginated list data or a member detail object.',
+    })
+    .describe('Member data from Congress.gov API.'),
   format: formatMembers,
 
   async handler(input, ctx) {
@@ -59,14 +78,22 @@ Once you have a bioguideId, use 'get' for full profile or 'sponsored'/'cosponsor
           "The 'district' parameter requires 'stateCode'. Provide both to look up a specific House representative.",
         );
       }
-      const result = await api.listMembers({
-        congress: input.congress,
-        stateCode: input.stateCode,
-        district: input.district,
-        currentMember: input.currentMember,
-        limit: input.limit,
-        offset: input.offset,
-      });
+      if (input.congress !== undefined && (input.stateCode || input.district !== undefined)) {
+        throw new Error(
+          "Congress.gov does not support combining 'congress' with stateCode or district for member lookups. Use congress-only or stateCode/district-only filters.",
+        );
+      }
+      const result = await api.listMembers(
+        {
+          congress: input.congress,
+          stateCode: input.stateCode,
+          district: input.district,
+          currentMember: input.currentMember,
+          limit: input.limit,
+          offset: input.offset,
+        },
+        ctx,
+      );
       ctx.log.info('Members listed', { count: result.data.length });
       return result;
     }
@@ -78,19 +105,22 @@ Once you have a bioguideId, use 'get' for full profile or 'sponsored'/'cosponsor
     }
 
     if (input.operation === 'get') {
-      const result = await api.getMember(input.bioguideId);
+      const result = await api.getMember(input.bioguideId, ctx);
       ctx.log.info('Member retrieved', { bioguideId: input.bioguideId });
       return result;
     }
 
     const type =
       input.operation === 'sponsored' ? 'sponsored-legislation' : 'cosponsored-legislation';
-    const result = await api.getMemberLegislation({
-      bioguideId: input.bioguideId,
-      type,
-      limit: input.limit,
-      offset: input.offset,
-    });
+    const result = await api.getMemberLegislation(
+      {
+        bioguideId: input.bioguideId,
+        type,
+        limit: input.limit,
+        offset: input.offset,
+      },
+      ctx,
+    );
     ctx.log.info('Member legislation retrieved', {
       bioguideId: input.bioguideId,
       type: input.operation,

--- a/src/mcp-server/tools/definitions/roll-votes.tool.ts
+++ b/src/mcp-server/tools/definitions/roll-votes.tool.ts
@@ -9,11 +9,7 @@ import { formatVotes } from '@/mcp-server/tools/format-helpers.js';
 import { getCongressApi } from '@/services/congress-api/congress-api-service.js';
 
 export const rollVotesTool = tool('congressgov_roll_votes', {
-  description: `Retrieve House roll call vote data and individual member voting positions.
-
-NOTE: Covers House votes only — Senate vote data is not yet in the Congress.gov API.
-
-Use 'list' to find votes by congress and session, 'get' for vote details (question, result, associated bill), and 'members' for how each representative voted.`,
+  description: `Retrieve House roll call vote data and individual member voting positions — House-only, as Senate vote data is not yet in the Congress.gov API. Use 'list' to find votes by congress and session, 'get' for vote details (question, result, associated bill), or 'members' for how each representative voted.`,
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
   input: z.object({
     operation: z.enum(['list', 'get', 'members']).describe('Which data to retrieve.'),
@@ -40,12 +36,15 @@ Use 'list' to find votes by congress and session, 'get' for vote details (questi
     const api = getCongressApi();
 
     if (input.operation === 'list') {
-      const result = await api.listVotes({
-        congress: input.congress,
-        session: input.session,
-        limit: input.limit,
-        offset: input.offset,
-      });
+      const result = await api.listVotes(
+        {
+          congress: input.congress,
+          session: input.session,
+          limit: input.limit,
+          offset: input.offset,
+        },
+        ctx,
+      );
       ctx.log.info('Votes listed', { congress: input.congress, session: input.session });
       return result;
     }
@@ -64,8 +63,8 @@ Use 'list' to find votes by congress and session, 'get' for vote details (questi
 
     const result =
       input.operation === 'members'
-        ? await api.getVoteMembers(voteParams)
-        : await api.getVote(voteParams);
+        ? await api.getVoteMembers(voteParams, ctx)
+        : await api.getVote(voteParams, ctx);
     ctx.log.info('Vote retrieved', {
       ...voteParams,
       operation: input.operation,

--- a/src/mcp-server/tools/definitions/senate-nominations.tool.ts
+++ b/src/mcp-server/tools/definitions/senate-nominations.tool.ts
@@ -9,11 +9,7 @@ import { formatNominations } from '@/mcp-server/tools/format-helpers.js';
 import { getCongressApi } from '@/services/congress-api/congress-api-service.js';
 
 export const senateNominationsTool = tool('congressgov_senate_nominations', {
-  description: `Browse presidential nominations to federal positions and track the Senate confirmation process.
-
-Nominations use 'PN' (Presidential Nomination) numbering. A single nomination may contain multiple nominees — use 'nominees' to see individual appointees.
-
-Partitioned nominations (e.g., PN230-1, PN230-2) occur when nominees within one nomination follow different confirmation paths.`,
+  description: `Browse presidential nominations to federal positions and track the Senate confirmation process. Nominations use 'PN' (Presidential Nomination) numbering, and a single nomination may contain multiple nominees — use 'nominees' to see individual appointees. Partitioned nominations (e.g., PN230-1, PN230-2) occur when nominees within one nomination follow different confirmation paths.`,
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
   input: z.object({
     operation: z
@@ -40,11 +36,14 @@ Partitioned nominations (e.g., PN230-1, PN230-2) occur when nominees within one 
     const api = getCongressApi();
 
     if (input.operation === 'list') {
-      const result = await api.listNominations({
-        congress: input.congress,
-        limit: input.limit,
-        offset: input.offset,
-      });
+      const result = await api.listNominations(
+        {
+          congress: input.congress,
+          limit: input.limit,
+          offset: input.offset,
+        },
+        ctx,
+      );
       ctx.log.info('Nominations listed', {
         congress: input.congress,
         count: result.data.length,
@@ -59,7 +58,7 @@ Partitioned nominations (e.g., PN230-1, PN230-2) occur when nominees within one 
     }
 
     if (input.operation === 'get') {
-      const result = await api.getNomination(input.congress, input.nominationNumber);
+      const result = await api.getNomination(input.congress, input.nominationNumber, ctx);
       ctx.log.info('Nomination retrieved', {
         congress: input.congress,
         nominationNumber: input.nominationNumber,
@@ -73,10 +72,16 @@ Partitioned nominations (e.g., PN230-1, PN230-2) occur when nominees within one 
           "The 'nominees' operation requires 'ordinal' — the position number within the nomination. Use 'get' first to see available ordinals in the nominees array.",
         );
       }
-      const result = await api.getNominee(input.congress, input.nominationNumber, input.ordinal, {
-        limit: input.limit,
-        offset: input.offset,
-      });
+      const result = await api.getNominee(
+        input.congress,
+        input.nominationNumber,
+        input.ordinal,
+        {
+          limit: input.limit,
+          offset: input.offset,
+        },
+        ctx,
+      );
       ctx.log.info('Nominee retrieved', {
         congress: input.congress,
         nominationNumber: input.nominationNumber,
@@ -85,13 +90,16 @@ Partitioned nominations (e.g., PN230-1, PN230-2) occur when nominees within one 
       return result;
     }
 
-    const result = await api.getNominationSubResource({
-      congress: input.congress,
-      nominationNumber: input.nominationNumber,
-      subResource: input.operation,
-      limit: input.limit,
-      offset: input.offset,
-    });
+    const result = await api.getNominationSubResource(
+      {
+        congress: input.congress,
+        nominationNumber: input.nominationNumber,
+        subResource: input.operation,
+        limit: input.limit,
+        offset: input.offset,
+      },
+      ctx,
+    );
     ctx.log.info('Nomination sub-resource retrieved', {
       congress: input.congress,
       nominationNumber: input.nominationNumber,

--- a/src/mcp-server/tools/format-helpers.ts
+++ b/src/mcp-server/tools/format-helpers.ts
@@ -55,15 +55,6 @@ function join(values: (string | undefined | null | false)[], sep = ' | '): strin
   return values.filter(Boolean).join(sep);
 }
 
-function withResponseNotes(result: Record<string, unknown>, text: string): string {
-  if (result.rawResponse == null) return text;
-  return [
-    text,
-    '',
-    '_Note: markdown output is summarized for readability. `rawResponse` preserves the full upstream Congress.gov envelope._',
-  ].join('\n');
-}
-
 // ── Rendering Core ──────────────────────────────────────────────────
 
 function pagHeader(result: Record<string, unknown>): string {
@@ -389,12 +380,11 @@ function makeFormatter(
   itemRenderer?: ItemRenderer,
 ): (result: Record<string, unknown>) => TextBlock[] {
   return (result) => {
-    if (Array.isArray(result.data))
-      return tb(withResponseNotes(result, renderList(result, itemRenderer)));
+    if (Array.isArray(result.data)) return tb(renderList(result, itemRenderer));
     for (const key of detailKeys) {
-      if (result[key] != null) return tb(withResponseNotes(result, renderDetail(result[key])));
+      if (result[key] != null) return tb(renderDetail(result[key]));
     }
-    return tb(withResponseNotes(result, renderDetail(result)));
+    return tb(renderDetail(result));
   };
 }
 
@@ -405,10 +395,10 @@ export function formatBills(result: Record<string, unknown>): TextBlock[] {
     const firstRecord =
       typeof first === 'object' && first !== null ? (first as Record<string, unknown>) : undefined;
     const isBills = !!firstRecord && 'title' in firstRecord && 'number' in firstRecord;
-    return tb(withResponseNotes(result, renderList(result, isBills ? renderBillItem : undefined)));
+    return tb(renderList(result, isBills ? renderBillItem : undefined));
   }
-  if (result.bill != null) return tb(withResponseNotes(result, renderDetail(result.bill)));
-  return tb(withResponseNotes(result, renderDetail(result)));
+  if (result.bill != null) return tb(renderDetail(result.bill));
+  return tb(renderDetail(result));
 }
 
 /** CRS bill summaries — "what's happening in Congress". */
@@ -420,14 +410,13 @@ export function formatMembers(result: Record<string, unknown>): TextBlock[] {
     const first = result.data[0];
     const firstRecord =
       typeof first === 'object' && first !== null ? (first as Record<string, unknown>) : undefined;
-    if (firstRecord && 'bioguideId' in firstRecord)
-      return tb(withResponseNotes(result, renderList(result, renderMemberItem)));
+    if (firstRecord && 'bioguideId' in firstRecord) return tb(renderList(result, renderMemberItem));
     if (firstRecord && 'number' in firstRecord && 'title' in firstRecord)
-      return tb(withResponseNotes(result, renderList(result, renderBillItem)));
-    return tb(withResponseNotes(result, renderList(result)));
+      return tb(renderList(result, renderBillItem));
+    return tb(renderList(result));
   }
-  if (result.member != null) return tb(withResponseNotes(result, renderDetail(result.member)));
-  return tb(withResponseNotes(result, renderDetail(result)));
+  if (result.member != null) return tb(renderDetail(result.member));
+  return tb(renderDetail(result));
 }
 
 /** Committee browse, detail, and sub-resources (bills, reports, nominations). */
@@ -438,10 +427,9 @@ export const formatCommitteeReports = makeFormatter(['report', 'text']);
 
 /** CRS policy analysis reports. */
 export function formatCrsReports(result: Record<string, unknown>): TextBlock[] {
-  if (Array.isArray(result.data))
-    return tb(withResponseNotes(result, renderList(result, renderCrsReportItem)));
-  if (result.report != null) return tb(withResponseNotes(result, renderDetail(result.report)));
-  return tb(withResponseNotes(result, renderDetail(result)));
+  if (Array.isArray(result.data)) return tb(renderList(result, renderCrsReportItem));
+  if (result.report != null) return tb(renderDetail(result.report));
+  return tb(renderDetail(result));
 }
 
 /** Daily Congressional Record — volumes, issues, articles. */

--- a/src/mcp-server/tools/format-helpers.ts
+++ b/src/mcp-server/tools/format-helpers.ts
@@ -55,8 +55,13 @@ function join(values: (string | undefined | null | false)[], sep = ' | '): strin
   return values.filter(Boolean).join(sep);
 }
 
-function isApiUrl(val: unknown): boolean {
-  return typeof val === 'string' && val.includes('api.congress.gov');
+function withResponseNotes(result: Record<string, unknown>, text: string): string {
+  if (result.rawResponse == null) return text;
+  return [
+    text,
+    '',
+    '_Note: markdown output is summarized for readability. `rawResponse` preserves the full upstream Congress.gov envelope._',
+  ].join('\n');
 }
 
 // ── Rendering Core ──────────────────────────────────────────────────
@@ -103,7 +108,6 @@ function renderDetail(obj: unknown): string {
 
   for (const [key, val] of Object.entries(record)) {
     if (val == null || val === '') continue;
-    if (isApiUrl(val)) continue;
 
     if (typeof val === 'string') {
       const cleaned = stripHtml(val);
@@ -151,7 +155,7 @@ function renderDetail(obj: unknown): string {
       } else {
         lines.push(`\n**${key}:**`);
         for (const [k2, v2] of Object.entries(nested)) {
-          if (v2 == null || v2 === '' || isApiUrl(v2)) continue;
+          if (v2 == null || v2 === '') continue;
           if (typeof v2 === 'string') lines.push(`  **${k2}:** ${stripHtml(v2)}`);
           else if (typeof v2 === 'number' || typeof v2 === 'boolean')
             lines.push(`  **${k2}:** ${v2}`);
@@ -187,7 +191,6 @@ function renderGenericItem(item: Record<string, unknown>, index: number): string
   for (const [key, val] of Object.entries(item)) {
     if (val == null || val === '') continue;
     if (HEADING_FIELDS.has(key)) continue;
-    if (isApiUrl(val)) continue;
 
     if (typeof val === 'string') {
       const cleaned = stripHtml(val);
@@ -216,6 +219,7 @@ function renderGenericItem(item: Record<string, unknown>, index: number): string
           if (typeof sub === 'object' && sub !== null)
             lines.push(`  - ${renderInline(sub as Record<string, unknown>)}`);
         }
+        if (val.length > 5) lines.push(`  - _...${val.length - 5} more_`);
       }
     }
   }
@@ -241,11 +245,17 @@ const HEADING_FIELDS = new Set([
 function renderInline(obj: Record<string, unknown>): string {
   const parts: string[] = [];
   for (const [key, val] of Object.entries(obj)) {
-    if (val == null || val === '' || isApiUrl(val)) continue;
-    if (typeof val === 'string') parts.push(stripHtml(val).slice(0, 120));
-    else if (typeof val === 'number' || typeof val === 'boolean') parts.push(`${key}: ${val}`);
+    if (val == null || val === '') continue;
+    if (typeof val === 'string') {
+      const cleaned = stripHtml(val);
+      const preview = cleaned.length > 120 ? `${cleaned.slice(0, 117)}...` : cleaned;
+      parts.push(`${key}: ${preview}`);
+    } else if (typeof val === 'number' || typeof val === 'boolean') parts.push(`${key}: ${val}`);
   }
-  return parts.join(', ') || JSON.stringify(obj).slice(0, 200);
+  if (parts.length > 0) return parts.join(', ');
+
+  const json = JSON.stringify(obj);
+  return json.length > 200 ? `${json.slice(0, 197)}...` : json;
 }
 
 // ── Domain-Specific Item Renderers ──────────────────────────────────
@@ -254,6 +264,7 @@ function renderBillItem(item: Record<string, unknown>, i: number): string {
   const type = s(item, 'type')?.toUpperCase() ?? '';
   const number = s(item, 'number') ?? '';
   const title = s(item, 'title') ?? 'Untitled';
+  const url = s(item, 'url');
   const id = type && number ? `${type} ${number}: ` : '';
 
   const lines = [`### ${i + 1}. ${id}${title}`];
@@ -282,6 +293,7 @@ function renderBillItem(item: Record<string, unknown>, i: number): string {
 
   const updated = s(item, 'updateDate');
   if (updated) lines.push(`**Updated:** ${updated}`);
+  if (url) lines.push(`**URL:** ${url}`);
 
   return lines.join('\n');
 }
@@ -289,6 +301,7 @@ function renderBillItem(item: Record<string, unknown>, i: number): string {
 function renderMemberItem(item: Record<string, unknown>, i: number): string {
   const name =
     s(item, 'name') ?? s(item, 'directOrderName') ?? s(item, 'fullName') ?? 'Unknown Member';
+  const url = s(item, 'url');
   const lines = [`### ${i + 1}. ${name}`];
 
   const meta = join([
@@ -321,6 +334,8 @@ function renderMemberItem(item: Record<string, unknown>, i: number): string {
     );
   }
 
+  if (url) lines.push(`**URL:** ${url}`);
+
   return lines.join('\n');
 }
 
@@ -331,8 +346,9 @@ function renderSummaryItem(item: Record<string, unknown>, i: number): string {
   const version = s(item, 'actionDesc') ?? s(item, 'versionCode') ?? '';
   const date = s(item, 'actionDate') ?? '';
   const text = s(item, 'text') ?? '';
+  const url = s(item, 'url') ?? s(item, 'bill', 'url');
 
-  const ref = billType && billNum ? `${billType} ${billNum}` : 'Bill';
+  const ref = billType && billNum ? `${billType} ${billNum}` : 'Bill reference not available';
   const heading = congress ? `${ref}, Congress ${congress}` : ref;
   const lines = [`### ${i + 1}. ${heading}`];
 
@@ -340,13 +356,28 @@ function renderSummaryItem(item: Record<string, unknown>, i: number): string {
   if (meta) lines.push(meta);
 
   const billTitle = s(item, 'bill', 'title');
-  if (billTitle) lines.push(`**Bill Title:** ${billTitle}`);
+  lines.push(`**Bill Title:** ${billTitle ?? 'Not available'}`);
 
   // The summary text is the critical data — the whole point of this tool
-  if (text) {
-    lines.push('');
-    lines.push(text);
-  }
+  lines.push('');
+  lines.push(text || '_Summary text not available._');
+  if (url) lines.push(`\n**URL:** ${url}`);
+
+  return lines.join('\n');
+}
+
+function renderCrsReportItem(item: Record<string, unknown>, i: number): string {
+  const reportNumber =
+    s(item, 'reportNumber') ?? s(item, 'number') ?? 'Report number not available';
+  const title = s(item, 'title') ?? 'Title not available';
+  const updated = s(item, 'updateDate') ?? s(item, 'date') ?? '';
+  const summary = s(item, 'summary') ?? s(item, 'abstract') ?? '';
+  const url = s(item, 'url');
+
+  const lines = [`### ${i + 1}. ${reportNumber}: ${title}`];
+  if (updated) lines.push(`**Updated:** ${updated}`);
+  lines.push(summary || '_Summary not available._');
+  if (url) lines.push(`**URL:** ${url}`);
 
   return lines.join('\n');
 }
@@ -358,23 +389,26 @@ function makeFormatter(
   itemRenderer?: ItemRenderer,
 ): (result: Record<string, unknown>) => TextBlock[] {
   return (result) => {
-    if (Array.isArray(result.data)) return tb(renderList(result, itemRenderer));
+    if (Array.isArray(result.data))
+      return tb(withResponseNotes(result, renderList(result, itemRenderer)));
     for (const key of detailKeys) {
-      if (result[key] != null) return tb(renderDetail(result[key]));
+      if (result[key] != null) return tb(withResponseNotes(result, renderDetail(result[key])));
     }
-    return tb(renderDetail(result));
+    return tb(withResponseNotes(result, renderDetail(result)));
   };
 }
 
 /** Bill browse, detail, and sub-resources (actions, amendments, cosponsors, etc.). */
 export function formatBills(result: Record<string, unknown>): TextBlock[] {
   if (Array.isArray(result.data)) {
-    const first = (result.data as Record<string, unknown>[])[0];
-    const isBills = first && 'title' in first && 'number' in first;
-    return tb(renderList(result, isBills ? renderBillItem : undefined));
+    const first = result.data[0];
+    const firstRecord =
+      typeof first === 'object' && first !== null ? (first as Record<string, unknown>) : undefined;
+    const isBills = !!firstRecord && 'title' in firstRecord && 'number' in firstRecord;
+    return tb(withResponseNotes(result, renderList(result, isBills ? renderBillItem : undefined)));
   }
-  if (result.bill != null) return tb(renderDetail(result.bill));
-  return tb(renderDetail(result));
+  if (result.bill != null) return tb(withResponseNotes(result, renderDetail(result.bill)));
+  return tb(withResponseNotes(result, renderDetail(result)));
 }
 
 /** CRS bill summaries — "what's happening in Congress". */
@@ -383,14 +417,17 @@ export const formatSummaries = makeFormatter([], renderSummaryItem);
 /** Member browse, detail, and sponsored/cosponsored legislation. */
 export function formatMembers(result: Record<string, unknown>): TextBlock[] {
   if (Array.isArray(result.data)) {
-    const first = (result.data as Record<string, unknown>[])[0];
-    if (first && 'bioguideId' in first) return tb(renderList(result, renderMemberItem));
-    if (first && 'number' in first && 'title' in first)
-      return tb(renderList(result, renderBillItem));
-    return tb(renderList(result));
+    const first = result.data[0];
+    const firstRecord =
+      typeof first === 'object' && first !== null ? (first as Record<string, unknown>) : undefined;
+    if (firstRecord && 'bioguideId' in firstRecord)
+      return tb(withResponseNotes(result, renderList(result, renderMemberItem)));
+    if (firstRecord && 'number' in firstRecord && 'title' in firstRecord)
+      return tb(withResponseNotes(result, renderList(result, renderBillItem)));
+    return tb(withResponseNotes(result, renderList(result)));
   }
-  if (result.member != null) return tb(renderDetail(result.member));
-  return tb(renderDetail(result));
+  if (result.member != null) return tb(withResponseNotes(result, renderDetail(result.member)));
+  return tb(withResponseNotes(result, renderDetail(result)));
 }
 
 /** Committee browse, detail, and sub-resources (bills, reports, nominations). */
@@ -400,7 +437,12 @@ export const formatCommittees = makeFormatter(['committee']);
 export const formatCommitteeReports = makeFormatter(['report', 'text']);
 
 /** CRS policy analysis reports. */
-export const formatCrsReports = makeFormatter(['report']);
+export function formatCrsReports(result: Record<string, unknown>): TextBlock[] {
+  if (Array.isArray(result.data))
+    return tb(withResponseNotes(result, renderList(result, renderCrsReportItem)));
+  if (result.report != null) return tb(withResponseNotes(result, renderDetail(result.report)));
+  return tb(withResponseNotes(result, renderDetail(result)));
+}
 
 /** Daily Congressional Record — volumes, issues, articles. */
 export const formatDailyRecord = makeFormatter([]);

--- a/src/mcp-server/tools/tool-helpers.ts
+++ b/src/mcp-server/tools/tool-helpers.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Shared schemas and small utilities for Congress.gov tool definitions.
+ * @module mcp-server/tools/tool-helpers
+ */
+
+import { z } from '@cyanheads/mcp-ts-core';
+
+export const StringOrNumberSchema = z.union([z.number(), z.string()]);
+
+export const UnknownRecordSchema = z.record(z.string(), z.unknown());
+
+export function createPaginationSchema(countDescription: string) {
+  return z.object({
+    count: z.number().int().nonnegative().describe(countDescription),
+    nextOffset: z
+      .number()
+      .int()
+      .nonnegative()
+      .nullable()
+      .describe('Offset to request the next page, or null when there is no next page.'),
+  });
+}
+
+export function normalizeOptionalString(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}

--- a/src/services/congress-api/congress-api-service.ts
+++ b/src/services/congress-api/congress-api-service.ts
@@ -42,12 +42,11 @@ import type {
 } from './types.js';
 
 type ApiRecord = Record<string, unknown>;
-type EntityResult<TKey extends string> = Record<TKey, ApiRecord> & { rawResponse: ApiRecord };
+type EntityResult<TKey extends string> = Record<TKey, ApiRecord>;
 
 interface FetchListResult {
   data: unknown[];
   pagination: Pagination;
-  rawResponse: ApiRecord;
   [key: string]: unknown;
 }
 
@@ -111,7 +110,7 @@ export class CongressApiService {
       `/bill/${params.congress}/${params.billType}/${params.billNumber}`,
       ctx,
     );
-    return { bill: data.bill as ApiRecord, rawResponse: data };
+    return { bill: data.bill as ApiRecord };
   }
 
   getBillSubResource(params: BillSubResourceParams, ctx?: Context): Promise<FetchListResult> {
@@ -130,11 +129,12 @@ export class CongressApiService {
   }
 
   async getLaw(params: GetLawParams, ctx?: Context): Promise<EntityResult<'law'>> {
+    /** Congress.gov returns the law endpoint payload under `bill` — a law is a bill that became law. */
     const data = await this.get(
       `/law/${params.congress}/${params.lawType}/${params.lawNumber}`,
       ctx,
     );
-    return { law: data.law as ApiRecord, rawResponse: data };
+    return { law: data.bill as ApiRecord };
   }
 
   // --- Members ---
@@ -167,7 +167,7 @@ export class CongressApiService {
 
   async getMember(bioguideId: string, ctx?: Context): Promise<EntityResult<'member'>> {
     const data = await this.get(`/member/${bioguideId}`, ctx);
-    return { member: data.member as ApiRecord, rawResponse: data };
+    return { member: data.member as ApiRecord };
   }
 
   getMemberLegislation(
@@ -195,7 +195,7 @@ export class CongressApiService {
     ctx?: Context,
   ): Promise<EntityResult<'committee'>> {
     const data = await this.get(`/committee/${chamber}/${committeeCode}`, ctx);
-    return { committee: data.committee as ApiRecord, rawResponse: data };
+    return { committee: data.committee as ApiRecord };
   }
 
   getCommitteeSubResource(
@@ -223,7 +223,7 @@ export class CongressApiService {
       `/house-vote/${params.congress}/${params.session}/${params.voteNumber}`,
       ctx,
     );
-    return { vote: (data.houseRollCallVote ?? data) as ApiRecord, rawResponse: data };
+    return { vote: (data.houseRollCallVote ?? data) as ApiRecord };
   }
 
   async getVoteMembers(params: GetVoteParams, ctx?: Context): Promise<EntityResult<'vote'>> {
@@ -231,7 +231,7 @@ export class CongressApiService {
       `/house-vote/${params.congress}/${params.session}/${params.voteNumber}/members`,
       ctx,
     );
-    return { vote: (data.houseRollCallVoteMemberVotes ?? data) as ApiRecord, rawResponse: data };
+    return { vote: (data.houseRollCallVoteMemberVotes ?? data) as ApiRecord };
   }
 
   // --- Nominations ---
@@ -246,7 +246,7 @@ export class CongressApiService {
     ctx?: Context,
   ): Promise<EntityResult<'nomination'>> {
     const data = await this.get(`/nomination/${congress}/${nominationNumber}`, ctx);
-    return { nomination: data.nomination as ApiRecord, rawResponse: data };
+    return { nomination: data.nomination as ApiRecord };
   }
 
   getNominee(
@@ -292,7 +292,7 @@ export class CongressApiService {
   async getCrsReport(params: GetCrsReportParams, ctx?: Context): Promise<EntityResult<'report'>> {
     try {
       const data = await this.get(`/crsreport/${params.reportNumber}`, ctx);
-      return { report: (data.CRSReport ?? data) as ApiRecord, rawResponse: data };
+      return { report: (data.CRSReport ?? data) as ApiRecord };
     } catch (error) {
       const statusCode =
         error instanceof McpError && typeof error.data?.statusCode === 'number'
@@ -343,7 +343,7 @@ export class CongressApiService {
         reportNumber: params.reportNumber,
       });
     }
-    return { report: report as ApiRecord, rawResponse: data };
+    return { report: report as ApiRecord };
   }
 
   async getCommitteeReportText(
@@ -401,7 +401,7 @@ export class CongressApiService {
     const data = await this.get(path, ctx, this.buildQuery(params, extraQuery));
     const items = this.extractListItems(data[listKey]);
     const pagination = this.extractPagination(data.pagination, items.length, params);
-    return { data: items, pagination, rawResponse: data };
+    return { data: items, pagination };
   }
 
   private extractPagination(

--- a/src/services/congress-api/congress-api-service.ts
+++ b/src/services/congress-api/congress-api-service.ts
@@ -3,7 +3,16 @@
  * @module services/congress-api/congress-api-service
  */
 
-import { notFound, rateLimited, serviceUnavailable } from '@cyanheads/mcp-ts-core/errors';
+import type { Context } from '@cyanheads/mcp-ts-core';
+import {
+  JsonRpcErrorCode,
+  McpError,
+  notFound,
+  rateLimited,
+  serviceUnavailable,
+  validationError,
+} from '@cyanheads/mcp-ts-core/errors';
+import { fetchWithTimeout, withRetry } from '@cyanheads/mcp-ts-core/utils';
 import { getServerConfig } from '@/config/server-config.js';
 import type {
   BillSubResourceParams,
@@ -32,16 +41,49 @@ import type {
   PaginationParams,
 } from './types.js';
 
+type ApiRecord = Record<string, unknown>;
+type EntityResult<TKey extends string> = Record<TKey, ApiRecord> & { rawResponse: ApiRecord };
+
 interface FetchListResult {
   data: unknown[];
   pagination: Pagination;
+  rawResponse: ApiRecord;
   [key: string]: unknown;
 }
 
-const MAX_RETRIES = 3;
+interface RequestContextLike extends Record<string, unknown> {
+  operation?: string;
+  requestId: string;
+  timestamp: string;
+}
+
+function isApiRecord(value: unknown): value is ApiRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function isNativeAbortSignal(value: unknown): value is AbortSignal {
+  if (
+    typeof AbortSignal !== 'function' ||
+    typeof AbortSignal.prototype.throwIfAborted !== 'function' ||
+    !value
+  ) {
+    return false;
+  }
+
+  try {
+    AbortSignal.prototype.throwIfAborted.call(value);
+    return true;
+  } catch (error) {
+    return !(error instanceof TypeError);
+  }
+}
+
+const MAX_ATTEMPTS = 3;
 const BASE_BACKOFF_MS = 1000;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 const RATE_LIMIT_MAX = 5000;
+const REQUEST_TIMEOUT_MS = 10_000;
+const HTML_RESPONSE_RE = /^\s*<(!DOCTYPE\s+html|html[\s>])/i;
 
 export class CongressApiService {
   private readonly apiKey: string;
@@ -57,121 +99,154 @@ export class CongressApiService {
 
   // --- Bills ---
 
-  listBills(params: ListBillsParams): Promise<FetchListResult> {
+  listBills(params: ListBillsParams, ctx?: Context): Promise<FetchListResult> {
     const path = params.billType
       ? `/bill/${params.congress}/${params.billType}`
       : `/bill/${params.congress}`;
-    return this.fetchList(path, 'bills', params);
+    return this.fetchList(path, 'bills', params, ctx);
   }
 
-  async getBill(params: GetBillParams): Promise<{ bill: unknown }> {
-    const data = await this.get(`/bill/${params.congress}/${params.billType}/${params.billNumber}`);
-    return { bill: data.bill };
+  async getBill(params: GetBillParams, ctx?: Context): Promise<EntityResult<'bill'>> {
+    const data = await this.get(
+      `/bill/${params.congress}/${params.billType}/${params.billNumber}`,
+      ctx,
+    );
+    return { bill: data.bill as ApiRecord, rawResponse: data };
   }
 
-  getBillSubResource(params: BillSubResourceParams): Promise<FetchListResult> {
+  getBillSubResource(params: BillSubResourceParams, ctx?: Context): Promise<FetchListResult> {
     const path = `/bill/${params.congress}/${params.billType}/${params.billNumber}/${params.subResource}`;
     const key = this.inferListKey(params.subResource);
-    return this.fetchList(path, key, params);
+    return this.fetchList(path, key, params, ctx);
   }
 
   // --- Laws ---
 
-  listLaws(params: ListLawsParams): Promise<FetchListResult> {
+  listLaws(params: ListLawsParams, ctx?: Context): Promise<FetchListResult> {
     const path = params.lawType
       ? `/law/${params.congress}/${params.lawType}`
       : `/law/${params.congress}`;
-    return this.fetchList(path, 'bills', params);
+    return this.fetchList(path, 'bills', params, ctx);
   }
 
-  async getLaw(params: GetLawParams): Promise<{ law: unknown }> {
-    const data = await this.get(`/law/${params.congress}/${params.lawType}/${params.lawNumber}`);
-    return { law: data.law };
+  async getLaw(params: GetLawParams, ctx?: Context): Promise<EntityResult<'law'>> {
+    const data = await this.get(
+      `/law/${params.congress}/${params.lawType}/${params.lawNumber}`,
+      ctx,
+    );
+    return { law: data.law as ApiRecord, rawResponse: data };
   }
 
   // --- Members ---
 
-  listMembers(params: ListMembersParams): Promise<FetchListResult> {
+  listMembers(params: ListMembersParams, ctx?: Context): Promise<FetchListResult> {
+    if (params.congress !== undefined && (params.stateCode || params.district !== undefined)) {
+      throw validationError(
+        'Congress.gov does not support combining congress with stateCode or district for member lookups. Use congress-only or stateCode/district-only filters.',
+        {
+          congress: params.congress,
+          stateCode: params.stateCode,
+          district: params.district,
+        },
+      );
+    }
+
     let path = '/member';
-    if (params.congress) path = `/member/congress/${params.congress}`;
     if (params.stateCode) {
       path = `/member/${params.stateCode}`;
       if (params.district !== undefined) path += `/${params.district}`;
+    } else if (params.congress) {
+      path = `/member/congress/${params.congress}`;
     }
-    const query: Record<string, string> = {};
-    if (params.currentMember !== undefined)
-      query.currentMember = params.currentMember ? 'true' : 'false';
-    return this.fetchList(path, 'members', params, query);
+    const extraQuery =
+      params.currentMember === undefined
+        ? undefined
+        : { currentMember: params.currentMember ? 'true' : 'false' };
+    return this.fetchList(path, 'members', params, ctx, extraQuery);
   }
 
-  async getMember(bioguideId: string): Promise<{ member: unknown }> {
-    const data = await this.get(`/member/${bioguideId}`);
-    return { member: data.member };
+  async getMember(bioguideId: string, ctx?: Context): Promise<EntityResult<'member'>> {
+    const data = await this.get(`/member/${bioguideId}`, ctx);
+    return { member: data.member as ApiRecord, rawResponse: data };
   }
 
-  getMemberLegislation(params: GetMemberLegislationParams): Promise<FetchListResult> {
+  getMemberLegislation(
+    params: GetMemberLegislationParams,
+    ctx?: Context,
+  ): Promise<FetchListResult> {
     const path = `/member/${params.bioguideId}/${params.type}`;
     const key = params.type.replace('-legislation', 'Legislation');
-    return this.fetchList(path, key, params);
+    return this.fetchList(path, key, params, ctx);
   }
 
   // --- Committees ---
 
-  listCommittees(params: ListCommitteesParams): Promise<FetchListResult> {
+  listCommittees(params: ListCommitteesParams, ctx?: Context): Promise<FetchListResult> {
     let path = '/committee';
     if (params.congress && params.chamber) path = `/committee/${params.congress}/${params.chamber}`;
     else if (params.congress) path = `/committee/${params.congress}`;
     else if (params.chamber) path = `/committee/${params.chamber}`;
-    return this.fetchList(path, 'committees', params);
+    return this.fetchList(path, 'committees', params, ctx);
   }
 
-  async getCommittee(chamber: string, committeeCode: string): Promise<{ committee: unknown }> {
-    const data = await this.get(`/committee/${chamber}/${committeeCode}`);
-    return { committee: data.committee };
+  async getCommittee(
+    chamber: string,
+    committeeCode: string,
+    ctx?: Context,
+  ): Promise<EntityResult<'committee'>> {
+    const data = await this.get(`/committee/${chamber}/${committeeCode}`, ctx);
+    return { committee: data.committee as ApiRecord, rawResponse: data };
   }
 
-  getCommitteeSubResource(params: CommitteeSubResourceParams): Promise<FetchListResult> {
+  getCommitteeSubResource(
+    params: CommitteeSubResourceParams,
+    ctx?: Context,
+  ): Promise<FetchListResult> {
     const path = `/committee/${params.chamber}/${params.committeeCode}/${params.subResource}`;
     const key = this.inferListKey(params.subResource);
-    return this.fetchList(path, key, params);
+    return this.fetchList(path, key, params, ctx);
   }
 
   // --- Votes ---
 
-  listVotes(params: ListVotesParams): Promise<FetchListResult> {
+  listVotes(params: ListVotesParams, ctx?: Context): Promise<FetchListResult> {
     return this.fetchList(
       `/house-vote/${params.congress}/${params.session}`,
       'houseRollCallVotes',
       params,
+      ctx,
     );
   }
 
-  async getVote(params: GetVoteParams): Promise<{ vote: unknown }> {
+  async getVote(params: GetVoteParams, ctx?: Context): Promise<EntityResult<'vote'>> {
     const data = await this.get(
       `/house-vote/${params.congress}/${params.session}/${params.voteNumber}`,
+      ctx,
     );
-    return { vote: data.houseRollCallVote ?? data };
+    return { vote: (data.houseRollCallVote ?? data) as ApiRecord, rawResponse: data };
   }
 
-  async getVoteMembers(params: GetVoteParams): Promise<{ vote: unknown }> {
+  async getVoteMembers(params: GetVoteParams, ctx?: Context): Promise<EntityResult<'vote'>> {
     const data = await this.get(
       `/house-vote/${params.congress}/${params.session}/${params.voteNumber}/members`,
+      ctx,
     );
-    return { vote: data.houseRollCallVoteMemberVotes ?? data };
+    return { vote: (data.houseRollCallVoteMemberVotes ?? data) as ApiRecord, rawResponse: data };
   }
 
   // --- Nominations ---
 
-  listNominations(params: ListNominationsParams): Promise<FetchListResult> {
-    return this.fetchList(`/nomination/${params.congress}`, 'nominations', params);
+  listNominations(params: ListNominationsParams, ctx?: Context): Promise<FetchListResult> {
+    return this.fetchList(`/nomination/${params.congress}`, 'nominations', params, ctx);
   }
 
   async getNomination(
     congress: number,
     nominationNumber: string,
-  ): Promise<{ nomination: unknown }> {
-    const data = await this.get(`/nomination/${congress}/${nominationNumber}`);
-    return { nomination: data.nomination };
+    ctx?: Context,
+  ): Promise<EntityResult<'nomination'>> {
+    const data = await this.get(`/nomination/${congress}/${nominationNumber}`, ctx);
+    return { nomination: data.nomination as ApiRecord, rawResponse: data };
   }
 
   getNominee(
@@ -179,62 +254,85 @@ export class CongressApiService {
     nominationNumber: string,
     ordinal: number,
     params?: PaginationParams,
+    ctx?: Context,
   ): Promise<FetchListResult> {
     return this.fetchList(
       `/nomination/${congress}/${nominationNumber}/${ordinal}`,
       'nominees',
       params,
+      ctx,
     );
   }
 
-  getNominationSubResource(params: NominationSubResourceParams): Promise<FetchListResult> {
+  getNominationSubResource(
+    params: NominationSubResourceParams,
+    ctx?: Context,
+  ): Promise<FetchListResult> {
     const path = `/nomination/${params.congress}/${params.nominationNumber}/${params.subResource}`;
     const key = this.inferListKey(params.subResource);
-    return this.fetchList(path, key, params);
+    return this.fetchList(path, key, params, ctx);
   }
 
   // --- Summaries ---
 
-  listSummaries(params: ListSummariesParams): Promise<FetchListResult> {
+  listSummaries(params: ListSummariesParams, ctx?: Context): Promise<FetchListResult> {
     let path = '/summaries';
     if (params.congress && params.billType)
       path = `/summaries/${params.congress}/${params.billType}`;
     else if (params.congress) path = `/summaries/${params.congress}`;
-    return this.fetchList(path, 'summaries', params);
+    return this.fetchList(path, 'summaries', params, ctx);
   }
 
   // --- CRS Reports ---
 
-  listCrsReports(params?: PaginationParams): Promise<FetchListResult> {
-    return this.fetchList('/crsreport', 'CRSReports', params);
+  listCrsReports(params?: PaginationParams, ctx?: Context): Promise<FetchListResult> {
+    return this.fetchList('/crsreport', 'CRSReports', params, ctx);
   }
 
-  async getCrsReport(params: GetCrsReportParams): Promise<{ report: unknown }> {
-    let data: Record<string, unknown>;
+  async getCrsReport(params: GetCrsReportParams, ctx?: Context): Promise<EntityResult<'report'>> {
     try {
-      data = await this.get(`/crsreport/${params.reportNumber}`);
-    } catch (err) {
-      // Upstream API returns 500 instead of 404 for nonexistent report IDs
-      if (err instanceof Error && err.message.includes('HTTP 500')) {
-        throw notFound('CRS report not found', { reportNumber: params.reportNumber });
+      const data = await this.get(`/crsreport/${params.reportNumber}`, ctx);
+      return { report: (data.CRSReport ?? data) as ApiRecord, rawResponse: data };
+    } catch (error) {
+      const statusCode =
+        error instanceof McpError && typeof error.data?.statusCode === 'number'
+          ? error.data.statusCode
+          : undefined;
+      const responseBody =
+        error instanceof McpError && typeof error.data?.responseBody === 'string'
+          ? error.data.responseBody
+          : '';
+
+      if (statusCode === 500 && this.isMissingEntityErrorBody(responseBody)) {
+        throw notFound(
+          'CRS report not found',
+          { reportNumber: params.reportNumber },
+          { cause: error },
+        );
       }
-      throw err;
+      throw error;
     }
-    return { report: data.CRSReport ?? data };
   }
 
   // --- Committee Reports ---
 
-  listCommitteeReports(params: ListCommitteeReportsParams): Promise<FetchListResult> {
+  listCommitteeReports(
+    params: ListCommitteeReportsParams,
+    ctx?: Context,
+  ): Promise<FetchListResult> {
     const path = params.reportType
       ? `/committee-report/${params.congress}/${params.reportType}`
       : `/committee-report/${params.congress}`;
-    return this.fetchList(path, 'reports', params);
+    return this.fetchList(path, 'reports', params, ctx);
   }
 
-  async getCommitteeReport(params: GetCommitteeReportParams): Promise<{ report: unknown }> {
+  async getCommitteeReport(
+    params: GetCommitteeReportParams,
+    ctx?: Context,
+  ): Promise<EntityResult<'report'>> {
     const data = await this.get(
       `/committee-report/${params.congress}/${params.reportType}/${params.reportNumber}`,
+      ctx,
     );
     const reports = data.committeeReports;
     const report = Array.isArray(reports) ? reports[0] : (reports ?? data);
@@ -245,44 +343,49 @@ export class CongressApiService {
         reportNumber: params.reportNumber,
       });
     }
-    return { report };
+    return { report: report as ApiRecord, rawResponse: data };
   }
 
-  async getCommitteeReportText(params: GetCommitteeReportParams): Promise<{ text: unknown }> {
+  async getCommitteeReportText(
+    params: GetCommitteeReportParams,
+    ctx?: Context,
+  ): Promise<{ text: unknown }> {
     const data = await this.get(
       `/committee-report/${params.congress}/${params.reportType}/${params.reportNumber}/text`,
+      ctx,
     );
     return { text: data.text ?? data['text-versions'] ?? data };
   }
 
   // --- Daily Congressional Record ---
 
-  listDailyRecord(params?: ListDailyRecordParams): Promise<FetchListResult> {
-    return this.fetchList('/daily-congressional-record', 'dailyCongressionalRecord', params);
+  listDailyRecord(params?: ListDailyRecordParams, ctx?: Context): Promise<FetchListResult> {
+    return this.fetchList('/daily-congressional-record', 'dailyCongressionalRecord', params, ctx);
   }
 
-  getDailyIssues(params: GetDailyIssuesParams): Promise<FetchListResult> {
+  getDailyIssues(params: GetDailyIssuesParams, ctx?: Context): Promise<FetchListResult> {
     return this.fetchList(
       `/daily-congressional-record/${params.volumeNumber}`,
       'dailyCongressionalRecord',
       params,
+      ctx,
     );
   }
 
-  getDailyArticles(params: GetDailyArticlesParams): Promise<FetchListResult> {
+  getDailyArticles(params: GetDailyArticlesParams, ctx?: Context): Promise<FetchListResult> {
     const path = `/daily-congressional-record/${params.volumeNumber}/${params.issueNumber}/articles`;
-    return this.fetchList(path, 'articles', params);
+    return this.fetchList(path, 'articles', params, ctx);
   }
 
   // --- Congress metadata ---
 
-  async getCurrentCongress(): Promise<CongressDetail> {
-    const data = await this.get('/congress/current');
+  async getCurrentCongress(ctx?: Context): Promise<CongressDetail> {
+    const data = await this.get('/congress/current', ctx);
     return data.congress;
   }
 
-  async getCongress(congress: number): Promise<CongressDetail> {
-    const data = await this.get(`/congress/${congress}`);
+  async getCongress(congress: number, ctx?: Context): Promise<CongressDetail> {
+    const data = await this.get(`/congress/${congress}`, ctx);
     return data.congress;
   }
 
@@ -292,24 +395,13 @@ export class CongressApiService {
     path: string,
     listKey: string,
     params?: PaginationParams & Partial<DateRangeParams>,
+    ctx?: Context,
     extraQuery?: Record<string, string>,
   ): Promise<FetchListResult> {
-    const query: Record<string, string> = { ...extraQuery };
-    if (params?.limit) query.limit = String(params.limit);
-    if (params?.offset) query.offset = String(params.offset);
-    if (params?.fromDateTime) query.fromDateTime = params.fromDateTime;
-    if (params?.toDateTime) query.toDateTime = params.toDateTime;
-
-    const data = await this.get(path, query);
-    const raw = data[listKey];
-    // Some endpoints (e.g. committee-bills) nest the array inside an object — unwrap it.
-    const items: unknown[] = Array.isArray(raw)
-      ? raw
-      : raw && typeof raw === 'object'
-        ? ((Object.values(raw).find(Array.isArray) as unknown[]) ?? [])
-        : [];
+    const data = await this.get(path, ctx, this.buildQuery(params, extraQuery));
+    const items = this.extractListItems(data[listKey]);
     const pagination = this.extractPagination(data.pagination, items.length, params);
-    return { data: items, pagination };
+    return { data: items, pagination, rawResponse: data };
   }
 
   private extractPagination(
@@ -325,54 +417,28 @@ export class CongressApiService {
   }
 
   // biome-ignore lint/suspicious/noExplicitAny: API responses are dynamic JSON
-  private async get(path: string, query?: Record<string, string>): Promise<any> {
+  private get(path: string, ctx?: Context, query?: Record<string, string>): Promise<any> {
     this.checkRateLimit();
 
-    const url = new URL(`${this.baseUrl}${path}`);
-    url.searchParams.set('format', 'json');
-    url.searchParams.set('api_key', this.apiKey);
-    if (query) {
-      for (const [k, v] of Object.entries(query)) {
-        if (v !== undefined && v !== '') url.searchParams.set(k, v);
-      }
-    }
+    const url = this.buildUrl(path, query);
+    const operation = `CongressApiService GET ${path}`;
+    const requestContext = this.getRequestContext(ctx, operation);
+    const signal = this.getAbortSignal(ctx);
+    const retryOptions = {
+      operation,
+      context: requestContext,
+      baseDelayMs: BASE_BACKOFF_MS,
+      maxRetries: MAX_ATTEMPTS - 1,
+      isTransient: (error: unknown) => this.isRetryableError(error),
+      ...(signal ? { signal } : {}),
+    };
 
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      const res = await fetch(url.toString(), {
-        headers: { Accept: 'application/json' },
-      });
-
-      if (res.status === 429) {
-        throw rateLimited(
-          'Congress.gov API rate limit reached (5,000 requests/hour). Wait before retrying — the limit resets hourly.',
-        );
-      }
-
-      if (res.status >= 500) {
-        const body = await res.text().catch(() => '');
-        // The API returns 500 instead of 404 for some nonexistent entities —
-        // these have structured JSON error bodies vs. empty/HTML for real outages
-        if (body.includes('"error"')) {
-          throw new Error(`Congress.gov API returned HTTP ${res.status}: ${body}`);
-        }
-        if (attempt < MAX_RETRIES - 1) {
-          await sleep(BASE_BACKOFF_MS * 2 ** attempt);
-          continue;
-        }
-        throw serviceUnavailable(
-          `Congress.gov API returned HTTP ${res.status} after ${MAX_RETRIES} attempts.`,
-          { status: res.status },
-        );
-      }
-
-      if (!res.ok) {
-        const body = await res.text().catch(() => '');
-        throw new Error(`Congress.gov API returned HTTP ${res.status}: ${body || res.statusText}`);
-      }
-
+    return withRetry(async () => {
+      const response = await this.fetchResponse(url, path, requestContext, signal);
+      const data = this.parseJsonResponse(await response.text(), path);
       this.requestCount++;
-      return res.json();
-    }
+      return data;
+    }, retryOptions);
   }
 
   private checkRateLimit(): void {
@@ -407,10 +473,133 @@ export class CongressApiService {
     };
     return mapping[subResource] ?? subResource;
   }
-}
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  private buildUrl(path: string, query?: Record<string, string>): URL {
+    const url = new URL(`${this.baseUrl}${path}`);
+    url.searchParams.set('format', 'json');
+    url.searchParams.set('api_key', this.apiKey);
+    if (query) {
+      for (const [k, v] of Object.entries(query)) {
+        if (v !== undefined && v !== '') url.searchParams.set(k, v);
+      }
+    }
+    return url;
+  }
+
+  private buildQuery(
+    params?: PaginationParams & Partial<DateRangeParams>,
+    extraQuery?: Record<string, string>,
+  ): Record<string, string> {
+    const query: Record<string, string> = { ...extraQuery };
+    if (params?.limit != null) query.limit = String(params.limit);
+    if (params?.offset != null) query.offset = String(params.offset);
+    if (params?.fromDateTime) query.fromDateTime = params.fromDateTime;
+    if (params?.toDateTime) query.toDateTime = params.toDateTime;
+    return query;
+  }
+
+  private extractListItems(raw: unknown): unknown[] {
+    if (Array.isArray(raw)) return raw;
+    if (!isApiRecord(raw)) return [];
+
+    const nestedItems = Object.values(raw).find(Array.isArray);
+    return Array.isArray(nestedItems) ? nestedItems : [];
+  }
+
+  private getRequestContext(ctx: Context | undefined, operation: string): RequestContextLike {
+    const ctxRecord = ctx as unknown as Record<string, unknown> | undefined;
+    const requestId =
+      typeof ctxRecord?.requestId === 'string' ? ctxRecord.requestId : 'congress-api-service';
+    const timestamp =
+      typeof ctxRecord?.timestamp === 'string' ? ctxRecord.timestamp : new Date().toISOString();
+    return { operation, requestId, timestamp };
+  }
+
+  private getAbortSignal(ctx?: Context): AbortSignal | undefined {
+    const signal = ctx?.signal;
+    return isNativeAbortSignal(signal) ? signal : undefined;
+  }
+
+  private async fetchResponse(
+    url: URL,
+    path: string,
+    requestContext: RequestContextLike,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    try {
+      return await fetchWithTimeout(url, REQUEST_TIMEOUT_MS, requestContext, {
+        headers: { Accept: 'application/json' },
+        ...(signal ? { signal } : {}),
+      });
+    } catch (error) {
+      if (error instanceof McpError && error.code === JsonRpcErrorCode.ServiceUnavailable) {
+        const statusCode =
+          typeof error.data?.statusCode === 'number' ? error.data.statusCode : undefined;
+        if (statusCode === 404) {
+          throw notFound('Congress.gov resource not found', { path }, { cause: error });
+        }
+        if (statusCode === 429) {
+          throw rateLimited(
+            'Congress.gov API rate limit reached (5,000 requests/hour). Wait before retrying — the limit resets hourly.',
+            { path },
+            { cause: error },
+          );
+        }
+      }
+      throw error;
+    }
+  }
+
+  private isRetryableError(error: unknown): boolean {
+    if (error instanceof McpError) {
+      return (
+        error.code === JsonRpcErrorCode.ServiceUnavailable ||
+        error.code === JsonRpcErrorCode.Timeout
+      );
+    }
+
+    return true;
+  }
+
+  private parseJsonResponse(text: string, path: string): Record<string, unknown> {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      throw serviceUnavailable('Congress.gov API returned an empty response body.', { path });
+    }
+    if (HTML_RESPONSE_RE.test(trimmed)) {
+      throw serviceUnavailable('Congress.gov API returned HTML instead of JSON.', {
+        path,
+      });
+    }
+
+    try {
+      return JSON.parse(trimmed) as Record<string, unknown>;
+    } catch (error) {
+      throw serviceUnavailable(
+        'Congress.gov API returned invalid JSON.',
+        { path },
+        { cause: error },
+      );
+    }
+  }
+
+  private isMissingEntityErrorBody(body: string): boolean {
+    const trimmed = body.trim();
+    if (!trimmed || HTML_RESPONSE_RE.test(trimmed)) return false;
+
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      const message =
+        typeof parsed.error === 'string'
+          ? parsed.error
+          : typeof parsed.message === 'string'
+            ? parsed.message
+            : '';
+      return /not found|no data/i.test(message);
+    } catch {
+      return false;
+    }
+  }
 }
 
 let _service: CongressApiService | undefined;

--- a/tests/mcp-server/resources/definitions/bill.resource.test.ts
+++ b/tests/mcp-server/resources/definitions/bill.resource.test.ts
@@ -35,11 +35,14 @@ describe('billResource', () => {
     });
     const result = await billResource.handler(params, ctx);
     expect(result).toEqual(billData);
-    expect(mockApi.getBill).toHaveBeenCalledWith({
-      congress: 118,
-      billType: 'hr',
-      billNumber: 3076,
-    });
+    expect(mockApi.getBill).toHaveBeenCalledWith(
+      {
+        congress: 118,
+        billType: 'hr',
+        billNumber: 3076,
+      },
+      ctx,
+    );
   });
 
   it('converts string params to numbers for API call', async () => {
@@ -51,10 +54,13 @@ describe('billResource', () => {
       billNumber: '1',
     });
     await billResource.handler(params, ctx);
-    expect(mockApi.getBill).toHaveBeenCalledWith({
-      congress: 119,
-      billType: 's',
-      billNumber: 1,
-    });
+    expect(mockApi.getBill).toHaveBeenCalledWith(
+      {
+        congress: 119,
+        billType: 's',
+        billNumber: 1,
+      },
+      ctx,
+    );
   });
 });

--- a/tests/mcp-server/resources/definitions/committee.resource.test.ts
+++ b/tests/mcp-server/resources/definitions/committee.resource.test.ts
@@ -29,7 +29,7 @@ describe('committeeResource', () => {
     mockApi.getCommittee.mockResolvedValue({ committee: { name: 'Judiciary' } });
     const params = committeeResource.params!.parse({ committeeCode: 'hsju00' });
     await committeeResource.handler(params, ctx);
-    expect(mockApi.getCommittee).toHaveBeenCalledWith('house', 'hsju00');
+    expect(mockApi.getCommittee).toHaveBeenCalledWith('house', 'hsju00', ctx);
   });
 
   it('infers senate chamber from s-prefix code', async () => {
@@ -37,7 +37,7 @@ describe('committeeResource', () => {
     mockApi.getCommittee.mockResolvedValue({ committee: { name: 'Finance' } });
     const params = committeeResource.params!.parse({ committeeCode: 'ssfi00' });
     await committeeResource.handler(params, ctx);
-    expect(mockApi.getCommittee).toHaveBeenCalledWith('senate', 'ssfi00');
+    expect(mockApi.getCommittee).toHaveBeenCalledWith('senate', 'ssfi00', ctx);
   });
 
   it('infers joint chamber from j-prefix code', async () => {
@@ -45,7 +45,7 @@ describe('committeeResource', () => {
     mockApi.getCommittee.mockResolvedValue({ committee: { name: 'Joint Economic' } });
     const params = committeeResource.params!.parse({ committeeCode: 'jsec00' });
     await committeeResource.handler(params, ctx);
-    expect(mockApi.getCommittee).toHaveBeenCalledWith('joint', 'jsec00');
+    expect(mockApi.getCommittee).toHaveBeenCalledWith('joint', 'jsec00', ctx);
   });
 
   it('returns committee data', async () => {

--- a/tests/mcp-server/resources/definitions/current-congress.resource.test.ts
+++ b/tests/mcp-server/resources/definitions/current-congress.resource.test.ts
@@ -37,5 +37,6 @@ describe('currentCongressResource', () => {
     const result = await currentCongressResource.handler({}, ctx);
     expect(result).toEqual(congressData);
     expect(result.congress).toBe(119);
+    expect(mockApi.getCurrentCongress).toHaveBeenCalledWith(ctx);
   });
 });

--- a/tests/mcp-server/resources/definitions/member.resource.test.ts
+++ b/tests/mcp-server/resources/definitions/member.resource.test.ts
@@ -31,6 +31,6 @@ describe('memberResource', () => {
     const params = memberResource.params!.parse({ bioguideId: 'P000197' });
     const result = await memberResource.handler(params, ctx);
     expect(result).toEqual(memberData);
-    expect(mockApi.getMember).toHaveBeenCalledWith('P000197');
+    expect(mockApi.getMember).toHaveBeenCalledWith('P000197', ctx);
   });
 });

--- a/tests/mcp-server/tools/definitions/bill-lookup.tool.test.ts
+++ b/tests/mcp-server/tools/definitions/bill-lookup.tool.test.ts
@@ -37,6 +37,7 @@ describe('billLookupTool', () => {
     expect(result.data).toHaveLength(2);
     expect(mockApi.listBills).toHaveBeenCalledWith(
       expect.objectContaining({ congress: 118, limit: 20, offset: 0 }),
+      ctx,
     );
   });
 
@@ -54,6 +55,7 @@ describe('billLookupTool', () => {
     await billLookupTool.handler(input, ctx);
     expect(mockApi.listBills).toHaveBeenCalledWith(
       expect.objectContaining({ congress: 118, billType: 'hr' }),
+      ctx,
     );
   });
 
@@ -68,11 +70,14 @@ describe('billLookupTool', () => {
     });
     const result = await billLookupTool.handler(input, ctx);
     expect(result.bill).toEqual({ title: 'Test Bill' });
-    expect(mockApi.getBill).toHaveBeenCalledWith({
-      congress: 118,
-      billType: 'hr',
-      billNumber: 1234,
-    });
+    expect(mockApi.getBill).toHaveBeenCalledWith(
+      {
+        congress: 118,
+        billType: 'hr',
+        billNumber: 1234,
+      },
+      ctx,
+    );
   });
 
   it('throws when get is missing billType or billNumber', async () => {
@@ -97,6 +102,7 @@ describe('billLookupTool', () => {
     expect(result.data).toHaveLength(1);
     expect(mockApi.getBillSubResource).toHaveBeenCalledWith(
       expect.objectContaining({ subResource: 'actions' }),
+      ctx,
     );
   });
 
@@ -115,7 +121,27 @@ describe('billLookupTool', () => {
     await billLookupTool.handler(input, ctx);
     expect(mockApi.getBillSubResource).toHaveBeenCalledWith(
       expect.objectContaining({ subResource: 'relatedbills' }),
+      ctx,
     );
+  });
+
+  it('ignores empty-string date filters from form-based clients', async () => {
+    const ctx = createMockContext();
+    mockApi.listBills.mockResolvedValue({
+      data: [],
+      pagination: { count: 0, nextOffset: null },
+    });
+    const input = billLookupTool.input.parse({
+      operation: 'list',
+      congress: 118,
+      fromDateTime: '',
+      toDateTime: '',
+    });
+    await billLookupTool.handler(input, ctx);
+    const [paramsArg, passedCtx] = mockApi.listBills.mock.calls[0];
+    expect(paramsArg.fromDateTime).toBeUndefined();
+    expect(paramsArg.toDateTime).toBeUndefined();
+    expect(passedCtx).toBe(ctx);
   });
 
   it('applies default limit and offset', () => {

--- a/tests/mcp-server/tools/definitions/bill-summaries.tool.test.ts
+++ b/tests/mcp-server/tools/definitions/bill-summaries.tool.test.ts
@@ -37,6 +37,7 @@ describe('billSummariesTool', () => {
       expect.objectContaining({
         fromDateTime: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
       }),
+      ctx,
     );
   });
 
@@ -56,6 +57,7 @@ describe('billSummariesTool', () => {
         fromDateTime: '2024-01-01T00:00:00Z',
         toDateTime: '2024-01-31T23:59:59Z',
       }),
+      ctx,
     );
   });
 
@@ -72,6 +74,7 @@ describe('billSummariesTool', () => {
     await billSummariesTool.handler(input, ctx);
     expect(mockApi.listSummaries).toHaveBeenCalledWith(
       expect.objectContaining({ congress: 118, billType: 'hr' }),
+      ctx,
     );
   });
 
@@ -79,5 +82,32 @@ describe('billSummariesTool', () => {
     const ctx = createMockContext();
     const input = billSummariesTool.input.parse({ billType: 'hr' });
     await expect(billSummariesTool.handler(input, ctx)).rejects.toThrow(/congress/);
+  });
+
+  it('treats empty-string dates from form-based clients as omitted', async () => {
+    const ctx = createMockContext();
+    mockApi.listSummaries.mockResolvedValue({
+      data: [],
+      pagination: { count: 0, nextOffset: null },
+    });
+    const input = billSummariesTool.input.parse({
+      fromDateTime: '',
+      toDateTime: '',
+    });
+    await billSummariesTool.handler(input, ctx);
+    const [paramsArg, passedCtx] = mockApi.listSummaries.mock.calls[0];
+    expect(paramsArg.fromDateTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(paramsArg.toDateTime).toBeUndefined();
+    expect(passedCtx).toBe(ctx);
+  });
+
+  it('formats sparse upstream summaries without inventing missing facts', () => {
+    const output = billSummariesTool.output.parse({
+      data: [{ bill: { congress: 118, type: 'hr', number: '1' } }],
+      pagination: { count: 1, nextOffset: null },
+    });
+    const blocks = billSummariesTool.format!(output);
+    expect((blocks[0] as { text: string }).text).toContain('Bill Title:** Not available');
+    expect((blocks[0] as { text: string }).text).toContain('Summary text not available');
   });
 });

--- a/tests/mcp-server/tools/definitions/committee-lookup.tool.test.ts
+++ b/tests/mcp-server/tools/definitions/committee-lookup.tool.test.ts
@@ -51,6 +51,7 @@ describe('committeeLookupTool', () => {
     await committeeLookupTool.handler(input, ctx);
     expect(mockApi.listCommittees).toHaveBeenCalledWith(
       expect.objectContaining({ congress: 118, chamber: 'senate' }),
+      ctx,
     );
   });
 
@@ -64,6 +65,7 @@ describe('committeeLookupTool', () => {
     });
     const result = await committeeLookupTool.handler(input, ctx);
     expect(result.committee).toEqual({ name: 'Judiciary' });
+    expect(mockApi.getCommittee).toHaveBeenCalledWith('house', 'hsju00', ctx);
   });
 
   it('throws when get is missing chamber or committeeCode', async () => {
@@ -96,6 +98,7 @@ describe('committeeLookupTool', () => {
     await committeeLookupTool.handler(input, ctx);
     expect(mockApi.getCommitteeSubResource).toHaveBeenCalledWith(
       expect.objectContaining({ subResource: 'bills' }),
+      ctx,
     );
   });
 });

--- a/tests/mcp-server/tools/definitions/committee-reports.tool.test.ts
+++ b/tests/mcp-server/tools/definitions/committee-reports.tool.test.ts
@@ -51,6 +51,7 @@ describe('committeeReportsTool', () => {
     await committeeReportsTool.handler(input, ctx);
     expect(mockApi.listCommitteeReports).toHaveBeenCalledWith(
       expect.objectContaining({ reportType: 'hrpt' }),
+      ctx,
     );
   });
 
@@ -65,6 +66,10 @@ describe('committeeReportsTool', () => {
     });
     const result = await committeeReportsTool.handler(input, ctx);
     expect(result.report).toEqual({ title: 'Report' });
+    expect(mockApi.getCommitteeReport).toHaveBeenCalledWith(
+      expect.objectContaining({ congress: 118, reportType: 'hrpt', reportNumber: 100 }),
+      ctx,
+    );
   });
 
   it('gets committee report text', async () => {
@@ -78,6 +83,10 @@ describe('committeeReportsTool', () => {
     });
     const result = await committeeReportsTool.handler(input, ctx);
     expect(result.text).toBe('Full text...');
+    expect(mockApi.getCommitteeReportText).toHaveBeenCalledWith(
+      expect.objectContaining({ congress: 118, reportType: 'srpt', reportNumber: 50 }),
+      ctx,
+    );
   });
 
   it('throws when get/text is missing reportType or reportNumber', async () => {

--- a/tests/mcp-server/tools/definitions/crs-reports.tool.test.ts
+++ b/tests/mcp-server/tools/definitions/crs-reports.tool.test.ts
@@ -66,19 +66,4 @@ describe('crsReportsTool', () => {
     const blocks = crsReportsTool.format!(output);
     expect((blocks[0] as { text: string }).text).toContain('Summary not available');
   });
-
-  it('signals when markdown output is summarizing a preserved raw response', () => {
-    const output = crsReportsTool.output.parse({
-      data: [{ reportNumber: 'R40097', url: 'https://api.congress.gov/v3/crsreport/R40097' }],
-      pagination: { count: 1, nextOffset: null },
-      rawResponse: {
-        CRSReports: [
-          { reportNumber: 'R40097', url: 'https://api.congress.gov/v3/crsreport/R40097' },
-        ],
-      },
-    });
-    const blocks = crsReportsTool.format!(output);
-    expect((blocks[0] as { text: string }).text).toContain('rawResponse');
-    expect((blocks[0] as { text: string }).text).toContain('api.congress.gov');
-  });
 });

--- a/tests/mcp-server/tools/definitions/crs-reports.tool.test.ts
+++ b/tests/mcp-server/tools/definitions/crs-reports.tool.test.ts
@@ -34,6 +34,10 @@ describe('crsReportsTool', () => {
     const input = crsReportsTool.input.parse({ operation: 'list' });
     const result = await crsReportsTool.handler(input, ctx);
     expect(result.data).toHaveLength(1);
+    expect(mockApi.listCrsReports).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 20, offset: 0 }),
+      ctx,
+    );
   });
 
   it('gets a specific CRS report', async () => {
@@ -45,11 +49,36 @@ describe('crsReportsTool', () => {
     });
     const result = await crsReportsTool.handler(input, ctx);
     expect(result.report).toEqual({ title: 'Climate Policy' });
+    expect(mockApi.getCrsReport).toHaveBeenCalledWith({ reportNumber: 'R40097' }, ctx);
   });
 
   it('throws when get is missing reportNumber', async () => {
     const ctx = createMockContext();
     const input = crsReportsTool.input.parse({ operation: 'get' });
     await expect(crsReportsTool.handler(input, ctx)).rejects.toThrow(/reportNumber/);
+  });
+
+  it('formats sparse CRS output without inventing summary text', () => {
+    const output = crsReportsTool.output.parse({
+      data: [{ reportNumber: 'R40097' }],
+      pagination: { count: 1, nextOffset: null },
+    });
+    const blocks = crsReportsTool.format!(output);
+    expect((blocks[0] as { text: string }).text).toContain('Summary not available');
+  });
+
+  it('signals when markdown output is summarizing a preserved raw response', () => {
+    const output = crsReportsTool.output.parse({
+      data: [{ reportNumber: 'R40097', url: 'https://api.congress.gov/v3/crsreport/R40097' }],
+      pagination: { count: 1, nextOffset: null },
+      rawResponse: {
+        CRSReports: [
+          { reportNumber: 'R40097', url: 'https://api.congress.gov/v3/crsreport/R40097' },
+        ],
+      },
+    });
+    const blocks = crsReportsTool.format!(output);
+    expect((blocks[0] as { text: string }).text).toContain('rawResponse');
+    expect((blocks[0] as { text: string }).text).toContain('api.congress.gov');
   });
 });

--- a/tests/mcp-server/tools/definitions/enacted-laws.tool.test.ts
+++ b/tests/mcp-server/tools/definitions/enacted-laws.tool.test.ts
@@ -34,7 +34,7 @@ describe('enactedLawsTool', () => {
     const input = enactedLawsTool.input.parse({ operation: 'list', congress: 118 });
     const result = await enactedLawsTool.handler(input, ctx);
     expect(result.data).toHaveLength(1);
-    expect(mockApi.listLaws).toHaveBeenCalledWith(expect.objectContaining({ congress: 118 }));
+    expect(mockApi.listLaws).toHaveBeenCalledWith(expect.objectContaining({ congress: 118 }), ctx);
   });
 
   it('lists laws filtered by type', async () => {
@@ -49,7 +49,7 @@ describe('enactedLawsTool', () => {
       lawType: 'pub',
     });
     await enactedLawsTool.handler(input, ctx);
-    expect(mockApi.listLaws).toHaveBeenCalledWith(expect.objectContaining({ lawType: 'pub' }));
+    expect(mockApi.listLaws).toHaveBeenCalledWith(expect.objectContaining({ lawType: 'pub' }), ctx);
   });
 
   it('gets a specific law', async () => {
@@ -63,6 +63,10 @@ describe('enactedLawsTool', () => {
     });
     const result = await enactedLawsTool.handler(input, ctx);
     expect(result.law).toEqual({ title: 'Public Law 118-1' });
+    expect(mockApi.getLaw).toHaveBeenCalledWith(
+      expect.objectContaining({ congress: 118, lawType: 'pub', lawNumber: 1 }),
+      ctx,
+    );
   });
 
   it('throws when get is missing lawType or lawNumber', async () => {

--- a/tests/mcp-server/tools/definitions/member-lookup.tool.test.ts
+++ b/tests/mcp-server/tools/definitions/member-lookup.tool.test.ts
@@ -48,13 +48,28 @@ describe('memberLookupTool', () => {
       stateCode: 'CA',
     });
     await memberLookupTool.handler(input, ctx);
-    expect(mockApi.listMembers).toHaveBeenCalledWith(expect.objectContaining({ stateCode: 'CA' }));
+    expect(mockApi.listMembers).toHaveBeenCalledWith(
+      expect.objectContaining({ stateCode: 'CA' }),
+      ctx,
+    );
   });
 
   it('throws when district is provided without stateCode', async () => {
     const ctx = createMockContext();
     const input = memberLookupTool.input.parse({ operation: 'list', district: 5 });
     await expect(memberLookupTool.handler(input, ctx)).rejects.toThrow(/stateCode/);
+  });
+
+  it('throws when congress is combined with state filters', async () => {
+    const ctx = createMockContext();
+    const input = memberLookupTool.input.parse({
+      operation: 'list',
+      congress: 118,
+      stateCode: 'CA',
+    });
+    await expect(memberLookupTool.handler(input, ctx)).rejects.toThrow(
+      /does not support combining/i,
+    );
   });
 
   it('gets a member by bioguideId', async () => {
@@ -66,6 +81,7 @@ describe('memberLookupTool', () => {
     });
     const result = await memberLookupTool.handler(input, ctx);
     expect(result.member).toEqual({ name: 'Pelosi' });
+    expect(mockApi.getMember).toHaveBeenCalledWith('P000197', ctx);
   });
 
   it('throws when get/sponsored/cosponsored is missing bioguideId', async () => {
@@ -87,6 +103,7 @@ describe('memberLookupTool', () => {
     await memberLookupTool.handler(input, ctx);
     expect(mockApi.getMemberLegislation).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'sponsored-legislation' }),
+      ctx,
     );
   });
 
@@ -103,6 +120,7 @@ describe('memberLookupTool', () => {
     await memberLookupTool.handler(input, ctx);
     expect(mockApi.getMemberLegislation).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'cosponsored-legislation' }),
+      ctx,
     );
   });
 });

--- a/tests/mcp-server/tools/definitions/senate-nominations.tool.test.ts
+++ b/tests/mcp-server/tools/definitions/senate-nominations.tool.test.ts
@@ -96,6 +96,7 @@ describe('senateNominationsTool', () => {
     await senateNominationsTool.handler(input, ctx);
     expect(mockApi.getNominationSubResource).toHaveBeenCalledWith(
       expect.objectContaining({ subResource: 'actions' }),
+      ctx,
     );
   });
 });

--- a/tests/services/congress-api/congress-api-service.test.ts
+++ b/tests/services/congress-api/congress-api-service.test.ts
@@ -3,6 +3,8 @@
  * @module tests/services/congress-api/congress-api-service.test
  */
 
+import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
+import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/config/server-config.js', () => ({
@@ -19,7 +21,16 @@ import {
 } from '@/services/congress-api/congress-api-service.js';
 
 function okJson(data: unknown) {
-  return { ok: true, status: 200, json: async () => data };
+  return { ok: true, status: 200, text: async () => JSON.stringify(data) };
+}
+
+function errorResponse(status: number, body: string, statusText = 'Error') {
+  return {
+    ok: false,
+    status,
+    statusText,
+    text: async () => body,
+  };
 }
 
 describe('CongressApiService', () => {
@@ -40,7 +51,7 @@ describe('CongressApiService', () => {
   describe('URL construction', () => {
     it('appends api_key and format=json to requests', async () => {
       mockFetch.mockResolvedValue(okJson({ congress: {} }));
-      await service.getCurrentCongress();
+      await service.getCurrentCongress(createMockContext());
       const url = new URL(mockFetch.mock.calls[0][0]);
       expect(url.searchParams.get('api_key')).toBe('test-api-key');
       expect(url.searchParams.get('format')).toBe('json');
@@ -48,21 +59,21 @@ describe('CongressApiService', () => {
 
     it('builds correct path for listBills', async () => {
       mockFetch.mockResolvedValue(okJson({ bills: [] }));
-      await service.listBills({ congress: 118 });
+      await service.listBills({ congress: 118 }, createMockContext());
       const url = new URL(mockFetch.mock.calls[0][0]);
       expect(url.pathname).toBe('/v3/bill/118');
     });
 
     it('builds correct path for listBills with billType', async () => {
       mockFetch.mockResolvedValue(okJson({ bills: [] }));
-      await service.listBills({ congress: 118, billType: 'hr' });
+      await service.listBills({ congress: 118, billType: 'hr' }, createMockContext());
       const url = new URL(mockFetch.mock.calls[0][0]);
       expect(url.pathname).toBe('/v3/bill/118/hr');
     });
 
     it('includes pagination params in query string', async () => {
       mockFetch.mockResolvedValue(okJson({ bills: [] }));
-      await service.listBills({ congress: 118, limit: 50, offset: 100 });
+      await service.listBills({ congress: 118, limit: 50, offset: 100 }, createMockContext());
       const url = new URL(mockFetch.mock.calls[0][0]);
       expect(url.searchParams.get('limit')).toBe('50');
       expect(url.searchParams.get('offset')).toBe('100');
@@ -71,24 +82,65 @@ describe('CongressApiService', () => {
 
   describe('error handling', () => {
     it('throws rate-limited error on 429', async () => {
-      mockFetch.mockResolvedValue({ ok: false, status: 429 });
-      await expect(service.getCurrentCongress()).rejects.toThrow(/rate limit/i);
+      mockFetch.mockResolvedValue(errorResponse(429, 'Too Many Requests', 'Too Many Requests'));
+      await expect(service.getCurrentCongress(createMockContext())).rejects.toMatchObject({
+        code: JsonRpcErrorCode.RateLimited,
+      });
     });
 
     it('throws service-unavailable error on 5xx after retries', async () => {
-      mockFetch.mockResolvedValue({ ok: false, status: 503, text: async () => '' });
-      await expect(service.getCurrentCongress()).rejects.toThrow(/HTTP 503/);
+      mockFetch.mockResolvedValue(errorResponse(503, '', 'Service Unavailable'));
+      await expect(service.getCurrentCongress(createMockContext())).rejects.toMatchObject({
+        code: JsonRpcErrorCode.ServiceUnavailable,
+      });
       expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
-    it('throws on non-ok response with body', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-        text: async () => 'Resource not found',
+    it('classifies 404 responses as not found', async () => {
+      mockFetch.mockResolvedValue(errorResponse(404, 'Resource not found', 'Not Found'));
+      await expect(service.getCurrentCongress(createMockContext())).rejects.toMatchObject({
+        code: JsonRpcErrorCode.NotFound,
       });
-      await expect(service.getCurrentCongress()).rejects.toThrow(/404/);
+    });
+
+    it('wraps network failures as service unavailable and retries them', async () => {
+      mockFetch.mockRejectedValue(new Error('socket hang up'));
+      await expect(service.getCurrentCongress(createMockContext())).rejects.toMatchObject({
+        code: JsonRpcErrorCode.ServiceUnavailable,
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('classifies structured CRS 500 responses as not found', async () => {
+      mockFetch.mockResolvedValue(
+        errorResponse(500, JSON.stringify({ error: 'No data found for report R99999' })),
+      );
+      await expect(
+        service.getCrsReport({ reportNumber: 'R99999' }, createMockContext()),
+      ).rejects.toMatchObject({
+        code: JsonRpcErrorCode.NotFound,
+      });
+    });
+
+    it('does not misclassify CRS outages as not found', async () => {
+      mockFetch.mockResolvedValue(
+        errorResponse(500, '<!DOCTYPE html><html><body>Unavailable</body></html>'),
+      );
+      await expect(
+        service.getCrsReport({ reportNumber: 'R99999' }, createMockContext()),
+      ).rejects.toMatchObject({
+        code: JsonRpcErrorCode.ServiceUnavailable,
+      });
+    });
+
+    it('ignores signal-like objects that are not native AbortSignal instances', async () => {
+      mockFetch.mockResolvedValue(okJson({ congress: {} }));
+      const ctx = {
+        ...createMockContext(),
+        signal: Object.create(AbortSignal.prototype),
+      };
+
+      await expect(service.getCurrentCongress(ctx as any)).resolves.toEqual({});
     });
   });
 
@@ -112,18 +164,34 @@ describe('CongressApiService', () => {
       mockFetch.mockResolvedValue(
         okJson({
           bills: [{ number: 1 }, { number: 2 }],
+          request: { format: 'json' },
           pagination: { count: 2 },
         }),
       );
-      const result = await service.listBills({ congress: 118 });
+      const result = await service.listBills({ congress: 118 }, createMockContext());
       expect(result.data).toHaveLength(2);
       expect(result.pagination.count).toBe(2);
+      expect(result.rawResponse).toMatchObject({
+        bills: [{ number: 1 }, { number: 2 }],
+        request: { format: 'json' },
+      });
     });
 
     it('returns empty array when list key is missing', async () => {
       mockFetch.mockResolvedValue(okJson({}));
-      const result = await service.listBills({ congress: 118 });
+      const result = await service.listBills({ congress: 118 }, createMockContext());
       expect(result.data).toEqual([]);
+    });
+
+    it('preserves mixed list item types instead of silently filtering them out', async () => {
+      mockFetch.mockResolvedValue(
+        okJson({
+          bills: ['raw-token', { number: 2 }],
+          pagination: { count: 2 },
+        }),
+      );
+      const result = await service.listBills({ congress: 118 }, createMockContext());
+      expect(result.data).toEqual(['raw-token', { number: 2 }]);
     });
   });
 
@@ -141,16 +209,25 @@ describe('CongressApiService', () => {
   describe('member endpoints', () => {
     it('builds correct path for listMembers with state and district', async () => {
       mockFetch.mockResolvedValue(okJson({ members: [] }));
-      await service.listMembers({ stateCode: 'CA', district: 12 });
+      await service.listMembers({ stateCode: 'CA', district: 12 }, createMockContext());
       const url = new URL(mockFetch.mock.calls[0][0]);
       expect(url.pathname).toBe('/v3/member/CA/12');
     });
 
     it('builds correct path for listMembers by congress', async () => {
       mockFetch.mockResolvedValue(okJson({ members: [] }));
-      await service.listMembers({ congress: 118 });
+      await service.listMembers({ congress: 118 }, createMockContext());
       const url = new URL(mockFetch.mock.calls[0][0]);
       expect(url.pathname).toBe('/v3/member/congress/118');
+    });
+
+    it('rejects ambiguous congress and location filters instead of silently dropping one', async () => {
+      try {
+        service.listMembers({ congress: 118, stateCode: 'CA' }, createMockContext());
+        expect.unreachable('Expected listMembers to throw');
+      } catch (error) {
+        expect(error).toMatchObject({ code: JsonRpcErrorCode.ValidationError });
+      }
     });
   });
 });

--- a/tests/services/congress-api/congress-api-service.test.ts
+++ b/tests/services/congress-api/congress-api-service.test.ts
@@ -171,10 +171,6 @@ describe('CongressApiService', () => {
       const result = await service.listBills({ congress: 118 }, createMockContext());
       expect(result.data).toHaveLength(2);
       expect(result.pagination.count).toBe(2);
-      expect(result.rawResponse).toMatchObject({
-        bills: [{ number: 1 }, { number: 2 }],
-        request: { format: 'json' },
-      });
     });
 
     it('returns empty array when list key is missing', async () => {
@@ -192,6 +188,25 @@ describe('CongressApiService', () => {
       );
       const result = await service.listBills({ congress: 118 }, createMockContext());
       expect(result.data).toEqual(['raw-token', { number: 2 }]);
+    });
+  });
+
+  describe('law endpoints', () => {
+    it('populates the law field from the upstream bill key', async () => {
+      mockFetch.mockResolvedValue(
+        okJson({
+          bill: { number: 4, title: 'NOTAM Improvement Act of 2023', type: 'HR' },
+          request: { format: 'json' },
+        }),
+      );
+      const result = await service.getLaw(
+        { congress: 118, lawType: 'pub', lawNumber: 4 },
+        createMockContext(),
+      );
+      expect(result.law).toMatchObject({
+        number: 4,
+        title: 'NOTAM Improvement Act of 2023',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
Release `0.3.8` and align the server with `@cyanheads/mcp-ts-core@^0.3.5`. This branch updates the Congress.gov service and MCP surface to the newer framework patterns, refreshes project agent/skill docs, and syncs the repo metadata for the patch release.

## Added
- `AGENTS.md` for non-Claude agents
- `skills/add-app-tool/SKILL.md` for MCP Apps tool and UI resource scaffolding
- shared tool schema helpers in `src/mcp-server/tools/tool-helpers.ts`

## Changed
- bumped `@cyanheads/mcp-ts-core` from `^0.2.10` to `^0.3.5`
- bumped `@biomejs/biome` to `^2.4.12`, `@types/node` to `^25.6.0`, `typescript` to `^6.0.3`, and `vitest` to `^4.1.4`
- updated Congress.gov tool and resource outputs to use stricter schemas, preserve pagination metadata, and pass request context through service calls. Tools return only normalized fields (`data`/`pagination` for lists, `bill`/`member`/`committee`/etc. for details) — upstream envelopes are no longer duplicated in structured output
- updated markdown formatters to surface upstream URLs and improve sparse-field handling
- updated `CongressApiService` to use framework retry and timeout utilities, and carry request context plus abort signals through HTTP calls
- refreshed project skills for direct `createApp()` registration guidance, external-service resilience, testing layout, field-test coverage, and devcheck expectations
- dropped the `overrides` block for `brace-expansion` and `path-to-regexp` — upstream chains now resolve to patched versions and `bun audit` is clean without them
- bumped release metadata to `0.3.8` across the changelog, README, package metadata, server metadata, and agent protocol headers

## Fixed
- `getLaw` now populates the normalized `law` field — Congress.gov returns the law endpoint payload under `bill`, not `law`, so the field was always undefined (regression caught by field-testing the server). Added a service-level test asserting `result.law` is populated
- CRS report error handling now distinguishes structured upstream "not found" responses from real service outages
- member lookup validation now rejects ambiguous requests that combine `congress` with location filters
- `CLAUDE.md` now uses `bun run test` in the commands table

## Reviewer Focus
- service-layer retry/timeout/context plumbing
- tool/resource output schema changes and formatter behavior around pagination and sparse fields
- `getLaw` field mapping fix and its service-level test
- regression coverage for CRS/member lookup edge cases and sparse upstream data rendering

## Validation
- `bun run test`
- `bun run devcheck`
